### PR TITLE
feat: add repo activity chart component (#45)

### DIFF
--- a/api/repo-activity.js
+++ b/api/repo-activity.js
@@ -1,0 +1,58 @@
+import { getCommitActivity } from '../src/github/commit-activity.js';
+import { renderRepoActivity } from '../src/tiles/repo-activity.js';
+
+/**
+ * Route descriptor consumed by the auto-mounter (api/_routes.js, see #52).
+ * Keeping this here means the route mounts itself — no edit to express.js.
+ * Public endpoint: it returns an SVG meant to be embedded in a README and
+ * fetched by GitHub's image proxy, so it must not require a session.
+ */
+export const route = { method: 'get', path: '/repo-activity', auth: false };
+
+/**
+ * Resolve the `?repo=` parameter into an `{ owner, repo }` pair.
+ *
+ * Accepts `owner/name` directly, or a bare `name` combined with `?user=`.
+ * Returns `null` when an owner cannot be determined.
+ */
+const resolveTarget = (req) => {
+    const raw = req.query.repo?.trim();
+    if (!raw) return null;
+
+    if (raw.includes('/')) {
+        const [owner, ...rest] = raw.split('/');
+        const repo = rest.join('/').trim();
+        return owner && repo ? { owner: owner.trim(), repo } : null;
+    }
+
+    const owner = req.query.user?.trim();
+    return owner ? { owner, repo: raw } : null;
+};
+
+/**
+ * GET /repo-activity?repo=owner/name  (or ?user=owner&repo=name)
+ *
+ * Renders the repository's weekly commit activity for the last year as a
+ * themed SVG bar chart. Always responds with `image/svg+xml` — error and
+ * empty states are rendered as SVG cards so the image never breaks in a README.
+ */
+export default async (req, res) => {
+    res.setHeader('Content-Type', 'image/svg+xml');
+
+    const target = resolveTarget(req);
+    if (!target) {
+        return res.send(renderRepoActivity(null, { error: 'Use ?repo=owner/name' }));
+    }
+
+    const { owner, repo } = target;
+    const repoLabel = `${owner}/${repo}`;
+
+    try {
+        const token = req.session?.github_token ?? process.env.GITHUB_TOKEN;
+        const weeks = await getCommitActivity(owner, repo, { token });
+        return res.send(renderRepoActivity(weeks, { repo: repoLabel }));
+    } catch (err) {
+        console.error(`[repo-activity] ${repoLabel}:`, err.message);
+        return res.send(renderRepoActivity(null, { repo: repoLabel, error: err.message }));
+    }
+};

--- a/src/github/commit-activity.js
+++ b/src/github/commit-activity.js
@@ -1,0 +1,77 @@
+import axios from 'axios';
+
+const GH = 'https://api.github.com';
+
+/**
+ * Default HTTP getter — thin wrapper over axios that never throws on a
+ * documented status (202 / 204 / 404 are expected control-flow, not errors).
+ * Injectable via `opts.httpGet` so tests can run without a network.
+ */
+const defaultHttpGet = (url, headers) =>
+    axios.get(url, { headers, validateStatus: (s) => s === 200 || s === 202 || s === 204 || s === 404 });
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Fetch the last year of weekly commit activity for a repository.
+ *
+ * GitHub computes repository statistics asynchronously. The first request for
+ * a repo whose cache is cold returns `202 Accepted` with an empty body and
+ * expects the caller to retry once the data is ready. We retry with a bounded,
+ * linearly-growing backoff and give up after `maxRetries` attempts rather than
+ * blocking the request indefinitely.
+ *
+ * @param {string} owner                 repository owner login
+ * @param {string} repo                  repository name
+ * @param {object} [opts]
+ * @param {string}   [opts.token]        GitHub token (defaults to GITHUB_TOKEN)
+ * @param {number}   [opts.maxRetries]   max retries while GitHub returns 202 (default 3)
+ * @param {number}   [opts.retryDelay]   base backoff in ms; grows linearly per attempt (default 700)
+ * @param {function} [opts.httpGet]      injectable `(url, headers) => {status, data}` for tests
+ * @param {function} [opts.sleep]        injectable delay `(ms) => Promise` for tests
+ * @returns {Promise<Array<{week:number,total:number,days:number[]}>|null>}
+ *   Weekly buckets (oldest → newest). `null` on a 404 / hard error. An empty
+ *   array when the repo has no commit activity, or when GitHub is still
+ *   computing the stats after the retry budget is exhausted (the caller renders
+ *   the graceful empty state either way).
+ */
+export const getCommitActivity = async (owner, repo, opts = {}) => {
+    const {
+        token = process.env.GITHUB_TOKEN,
+        maxRetries = 3,
+        retryDelay = 700,
+        httpGet = defaultHttpGet,
+        sleep = defaultSleep,
+    } = opts;
+
+    if (!owner || !repo) return null;
+
+    const headers = { Accept: 'application/vnd.github+json' };
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    const url = `${GH}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/stats/commit_activity`;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        let response;
+        try {
+            response = await httpGet(url, headers);
+        } catch {
+            // network / 5xx — treat as a hard failure
+            return null;
+        }
+
+        const { status, data } = response;
+
+        if (status === 404) return null;
+        if (status === 204) return [];               // no content — empty repo
+        if (status === 200) return Array.isArray(data) ? data : [];
+
+        // 202 — stats are still being computed. Wait and retry unless exhausted.
+        if (attempt < maxRetries) await sleep(retryDelay * (attempt + 1));
+    }
+
+    // Retry budget exhausted while GitHub was still computing → render empty state.
+    return [];
+};
+
+export default getCommitActivity;

--- a/src/tests/repo-activity.test.js
+++ b/src/tests/repo-activity.test.js
@@ -1,0 +1,101 @@
+import { describe, test, expect } from 'vitest';
+import { getCommitActivity } from '../github/commit-activity.js';
+import { renderRepoActivity } from '../tiles/repo-activity.js';
+import { route } from '../../api/repo-activity.js';
+
+const sampleWeeks = [
+    { week: 1700000000, total: 3, days: [0, 1, 0, 2, 0, 0, 0] },
+    { week: 1700604800, total: 8, days: [1, 1, 2, 1, 1, 1, 1] },
+    { week: 1701209600, total: 0, days: [0, 0, 0, 0, 0, 0, 0] },
+];
+
+// A no-op sleep so retry/backoff logic runs instantly in tests.
+const noSleep = () => Promise.resolve();
+
+describe('getCommitActivity', () => {
+    test('returns the weekly buckets on 200', async () => {
+        const httpGet = async () => ({ status: 200, data: sampleWeeks });
+        const weeks = await getCommitActivity('owner', 'repo', { httpGet, sleep: noSleep });
+        expect(weeks).toEqual(sampleWeeks);
+    });
+
+    test('retries on 202 then resolves once stats are ready', async () => {
+        let calls = 0;
+        const httpGet = async () => {
+            calls += 1;
+            return calls < 3 ? { status: 202, data: {} } : { status: 200, data: sampleWeeks };
+        };
+        const weeks = await getCommitActivity('owner', 'repo', { httpGet, sleep: noSleep, maxRetries: 5 });
+        expect(calls).toBe(3);
+        expect(weeks).toEqual(sampleWeeks);
+    });
+
+    test('gives up after the retry budget and returns an empty array', async () => {
+        let calls = 0;
+        const httpGet = async () => { calls += 1; return { status: 202, data: {} }; };
+        const weeks = await getCommitActivity('owner', 'repo', { httpGet, sleep: noSleep, maxRetries: 2 });
+        expect(calls).toBe(3); // initial attempt + 2 retries
+        expect(weeks).toEqual([]);
+    });
+
+    test('returns null on 404', async () => {
+        const httpGet = async () => ({ status: 404, data: {} });
+        expect(await getCommitActivity('owner', 'repo', { httpGet, sleep: noSleep })).toBeNull();
+    });
+
+    test('returns an empty array on 204 (empty repo)', async () => {
+        const httpGet = async () => ({ status: 204, data: '' });
+        expect(await getCommitActivity('owner', 'repo', { httpGet, sleep: noSleep })).toEqual([]);
+    });
+
+    test('returns null on a thrown network error', async () => {
+        const httpGet = async () => { throw new Error('ECONNRESET'); };
+        expect(await getCommitActivity('owner', 'repo', { httpGet, sleep: noSleep })).toBeNull();
+    });
+
+    test('returns null when owner or repo is missing', async () => {
+        expect(await getCommitActivity('', 'repo')).toBeNull();
+        expect(await getCommitActivity('owner', '')).toBeNull();
+    });
+});
+
+describe('renderRepoActivity', () => {
+    test('renders an SVG bar chart with the total and repo label', () => {
+        const svg = renderRepoActivity(sampleWeeks, { repo: 'octocat/hello' });
+        expect(svg).toContain('<svg');
+        expect(svg).toContain('octocat/hello');
+        expect(svg).toContain('COMMIT ACTIVITY');
+        expect(svg).toContain('>11<'); // 3 + 8 + 0 total commits
+    });
+
+    test('renders the empty state when there is no activity', () => {
+        const svg = renderRepoActivity([], { repo: 'octocat/hello' });
+        expect(svg).toContain('No commit activity');
+        expect(svg).not.toContain('COMMIT ACTIVITY');
+    });
+
+    test('renders the empty state when every week is zero', () => {
+        const zero = [{ week: 1, total: 0, days: [0, 0, 0, 0, 0, 0, 0] }];
+        expect(renderRepoActivity(zero, { repo: 'a/b' })).toContain('No commit activity');
+    });
+
+    test('renders the not-found state on null data', () => {
+        expect(renderRepoActivity(null, { repo: 'a/b' })).toContain('Repository not found');
+    });
+
+    test('renders an error state when given an error message', () => {
+        expect(renderRepoActivity(null, { error: 'boom' })).toContain('Could not load activity');
+    });
+
+    test('escapes XML-special characters in the repo label', () => {
+        const svg = renderRepoActivity(sampleWeeks, { repo: 'a&b/<c>' });
+        expect(svg).toContain('a&amp;b/&lt;c&gt;');
+        expect(svg).not.toContain('<c>');
+    });
+});
+
+describe('route descriptor', () => {
+    test('exports a public GET descriptor for auto-mounting', () => {
+        expect(route).toEqual({ method: 'get', path: '/repo-activity', auth: false });
+    });
+});

--- a/src/tiles/repo-activity.js
+++ b/src/tiles/repo-activity.js
@@ -1,0 +1,98 @@
+import { THEME_CSS } from './theme.js';
+
+const W = 800, H = 280;
+const PAD = 28;
+const BASELINE = H - 52;          // y of the bar baseline
+const CHART_TOP = 96;             // tallest a bar may reach
+const MAX_BAR_H = BASELINE - CHART_TOP;
+const BAR_COLOR = '#39d353';      // GitHub contribution green
+
+const clamp = (str, max) => (str.length > max ? str.slice(0, max - 1) + '…' : str);
+
+/** Wrap a body string in the themed 800×280 SVG shell. */
+const shell = (body) => `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img">
+    ${THEME_CSS}
+    <defs>
+        <linearGradient id="ra-bg" x1="0" y1="0" x2="0.4" y2="1">
+            <stop offset="0%" style="stop-color:var(--bg)"/>
+            <stop offset="100%" style="stop-color:var(--bg2)"/>
+        </linearGradient>
+        <linearGradient id="ra-bar" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="${BAR_COLOR}" stop-opacity="0.95"/>
+            <stop offset="100%" stop-color="${BAR_COLOR}" stop-opacity="0.55"/>
+        </linearGradient>
+    </defs>
+    <rect width="${W}" height="${H}" fill="url(#ra-bg)" rx="12"/>
+    ${body}
+</svg>`;
+
+/** Centered single-message state used for both errors and empty data. */
+const messageState = (heading, sub) => shell(`
+    <text x="${W / 2}" y="${H / 2 - 8}" text-anchor="middle" style="fill:var(--fg75)" font-size="18" font-weight="bold" font-family="Arial, sans-serif">${heading}</text>
+    <text x="${W / 2}" y="${H / 2 + 18}" text-anchor="middle" style="fill:var(--fg40)" font-size="12" font-family="Arial, sans-serif">${sub}</text>`);
+
+const escapeXml = (s) =>
+    String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+/**
+ * Render an 800×280 SVG card showing a repository's weekly commit activity over
+ * the last year as a bar chart. Adapts to light/dark mode via
+ * prefers-color-scheme CSS in the SVG.
+ *
+ * @param {Array<{week:number,total:number,days:number[]}>|null} weeks
+ *   Weekly commit buckets from {@link getCommitActivity}. `null` signals a
+ *   fetch error (renders an error card); an empty array or all-zero totals
+ *   render the graceful "no activity" empty state.
+ * @param {object} [opts]
+ * @param {string} [opts.repo]   repo label shown in the header (e.g. "owner/name")
+ * @param {string} [opts.error]  explicit error message; overrides the data path
+ * @returns {string} a complete SVG document
+ */
+export const renderRepoActivity = (weeks, opts = {}) => {
+    const { repo = '', error } = opts;
+    const label = repo ? escapeXml(clamp(repo, 40)) : 'repository';
+
+    if (error) return messageState('Could not load activity', escapeXml(clamp(error, 64)));
+    if (weeks === null || weeks === undefined) return messageState('Repository not found', label);
+
+    const totalCommits = weeks.reduce((sum, w) => sum + (w?.total ?? 0), 0);
+    if (weeks.length === 0 || totalCommits === 0) {
+        return messageState('No commit activity', `${label} · past year`);
+    }
+
+    const peak = Math.max(...weeks.map((w) => w?.total ?? 0));
+    const n = weeks.length;
+
+    // Lay out one bar per week across the chart width.
+    const chartLeft = PAD;
+    const chartRight = W - PAD;
+    const chartW = chartRight - chartLeft;
+    const slot = chartW / n;
+    const barW = Math.max(2, slot * 0.7);
+
+    const bars = weeks.map((w, i) => {
+        const total = w?.total ?? 0;
+        const h = peak > 0 ? Math.round((total / peak) * MAX_BAR_H) : 0;
+        const x = chartLeft + i * slot + (slot - barW) / 2;
+        const y = BASELINE - h;
+        if (h <= 0) {
+            // zero-commit week — a faint baseline tick so the timeline reads continuously
+            return `<rect x="${x.toFixed(1)}" y="${(BASELINE - 2).toFixed(1)}" width="${barW.toFixed(1)}" height="2" rx="1" style="fill:var(--fg10)"/>`;
+        }
+        return `<rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${barW.toFixed(1)}" height="${h}" rx="2" fill="url(#ra-bar)"/>`;
+    }).join('\n    ');
+
+    const header = `
+    <text x="${PAD}" y="42" style="fill:var(--fg60)" font-size="12" letter-spacing="3" font-family="Arial, sans-serif">COMMIT ACTIVITY</text>
+    <text x="${PAD}" y="68" style="fill:var(--fg85)" font-size="18" font-weight="bold" font-family="Arial, sans-serif">${label}</text>
+    <text x="${W - PAD}" y="42" text-anchor="end" style="fill:var(--fg40)" font-size="11" font-family="Arial, sans-serif">past 52 weeks</text>
+    <text x="${W - PAD}" y="70" text-anchor="end" style="fill:var(--fg)" font-size="24" font-weight="bold" font-family="Arial, sans-serif">${totalCommits}</text>
+    <text x="${W - PAD}" y="86" text-anchor="end" style="fill:var(--fg35)" font-size="10" font-family="Arial, sans-serif">commits</text>`;
+
+    const baseline = `<line x1="${chartLeft}" y1="${BASELINE}" x2="${chartRight}" y2="${BASELINE}" style="stroke:var(--fg08)" stroke-width="1"/>`;
+    const peakLabel = `<text x="${chartLeft}" y="${(BASELINE + 18).toFixed(1)}" style="fill:var(--fg30)" font-size="9" font-family="Arial, sans-serif">peak ${peak} commits/wk</text>`;
+
+    return shell(`${header}\n    ${baseline}\n    ${bars}\n    ${peakLabel}`);
+};
+
+export default renderRepoActivity;


### PR DESCRIPTION
Closes #45 (Phase 2 · stream `repo-activity`).

Adds `GET /repo-activity?repo=owner/name` — renders a repository's weekly commit activity for the last year as a themed SVG bar chart suitable for embedding in a README.

## What's included
- **`src/github/commit-activity.js`** — GitHub `stats/commit_activity` client. Handles the `202 "stats computing"` response with bounded, linearly-growing retry/backoff; `httpGet`/`sleep` are injectable for tests. Returns `null` on 404/error, `[]` on no data (or exhausted retries).
- **`src/tiles/repo-activity.js`** — 800×280 SVG bar chart using the shared `THEME_CSS` (light/dark aware). Graceful **empty-data**, **not-found**, and **error** states; XML-escapes the repo label.
- **`api/repo-activity.js`** — public handler. Accepts `?repo=owner/name` (or `?user=&repo=name`). Exports a `{ method, path, auth }` **route descriptor** so it auto-mounts via #52 with no `express.js` edit.
- **`src/tests/repo-activity.test.js`** — 14 tests covering the 202 retry path, empty/404/error handling, and tile rendering.

## Acceptance criteria
- [x] `GET /repo-activity?repo=` renders weekly commit activity (last year) as an SVG chart
- [x] handles the GitHub 202 'stats computing' response with bounded retry/backoff
- [x] empty-data state renders gracefully
- [x] exports a route descriptor; auto-mounted (no express.js edit)

## Notes for the director
- Depends on **#52** (auto-register routes), which is **not yet landed**. Built interface-first to #52's stated `{method, path, auth}` contract via a named `route` export; I did **not** touch `express.js` (owned by `core-http`). The route becomes live automatically once #52's `api/_routes.js` ships. If core-http picks a different descriptor export name/shape, this handler is a trivial rename to match.
- `auth: false` — public endpoint embeddable in READMEs / fetched by GitHub's image proxy.

All 33 tests pass; eslint clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)