### PR TITLE
feat: repo-components — tech badges + repo stats card (#43, #44)

### DIFF
--- a/api/repo-card.js
+++ b/api/repo-card.js
@@ -1,0 +1,71 @@
+import { renderRepoCard } from '../src/tiles/repo-card.js';
+import { lookupIcon } from '../src/github/tech-data.js';
+
+const GH = 'https://api.github.com';
+
+/** Parses the `repo` query param ("owner/name") into { owner, name }, or null. */
+const parseRepo = (value) => {
+    if (!value || typeof value !== 'string') return null;
+    const parts = value.split('/').map((s) => s.trim()).filter(Boolean);
+    if (parts.length !== 2) return null;
+    return { owner: parts[0], name: parts[1] };
+};
+
+/**
+ * Maps the REST repo object to the renderer's data shape, resolving a
+ * language colour from simple-icons when available.
+ */
+export const toCardData = (data) => {
+    const language = data.language ?? '';
+    const icon     = language ? lookupIcon(language) : null;
+    return {
+        owner:       data.owner?.login ?? '',
+        name:        data.name ?? '',
+        description: data.description ?? '',
+        stars:       data.stargazers_count ?? 0,
+        forks:       data.forks_count ?? 0,
+        openIssues:  data.open_issues_count ?? 0,
+        language,
+        languageHex: icon ? icon.hex : '8b949e',
+        updatedAt:   data.pushed_at ?? data.updated_at ?? '',
+    };
+};
+
+const fetchRepo = async (owner, name, token) => {
+    const headers = { Accept: 'application/vnd.github+json' };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const res = await fetch(`${GH}/repos/${owner}/${name}`, { headers });
+    if (!res.ok) return null;
+    return res.json();
+};
+
+/**
+ * GET /repo-card?repo=owner/name
+ *
+ * Renders a theme-aware SVG card with the repo's stars, forks, open issues,
+ * primary language and last-updated time, sourced from the REST repo object.
+ */
+export default async (req, res) => {
+    const parsed = parseRepo(req.query.repo);
+    if (!parsed) {
+        return res.status(400).type('text/plain').send('Missing or malformed `repo` (expected owner/name)');
+    }
+
+    res.setHeader('Content-Type', 'image/svg+xml');
+
+    try {
+        const token = req.session?.github_token ?? process.env.GITHUB_TOKEN;
+        const data  = await fetchRepo(parsed.owner, parsed.name, token);
+        if (!data) return res.status(404).type('text/plain').send(`Repo not found: ${parsed.owner}/${parsed.name}`);
+
+        return res.send(renderRepoCard(toCardData(data)));
+    } catch (err) {
+        return res.status(502).type('text/plain').send(`Failed to fetch repo: ${err.message}`);
+    }
+};
+
+// Route descriptor for the auto-mounting registry (#52). Mounts at
+// GET /repo-card with no express.js edit once the registry lands.
+export const route = { method: 'get', path: '/repo-card', auth: false };
+
+export { parseRepo };

--- a/api/repo-tech-badges.js
+++ b/api/repo-tech-badges.js
@@ -1,0 +1,61 @@
+import { techBadges } from '../src/markdown/tech-badges.js';
+
+const GH = 'https://api.github.com';
+
+/**
+ * Parses the `repo` query param into { owner, name }.
+ * Accepts "owner/name"; returns null when malformed.
+ */
+const parseRepo = (value) => {
+    if (!value || typeof value !== 'string') return null;
+    const parts = value.split('/').map((s) => s.trim()).filter(Boolean);
+    if (parts.length !== 2) return null;
+    return { owner: parts[0], name: parts[1] };
+};
+
+/**
+ * Fetches the REST repo object (language + topics) for owner/name.
+ * Uses the caller's GitHub token when present (higher rate limit + private repos).
+ *
+ * @returns {Promise<{ language: string, topics: string[] } | null>} null when not found
+ */
+export const fetchRepoMeta = async (owner, name, token) => {
+    const headers = { Accept: 'application/vnd.github+json' };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const res = await fetch(`${GH}/repos/${owner}/${name}`, { headers });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return { language: data.language ?? '', topics: data.topics ?? [] };
+};
+
+/**
+ * GET /repo-tech-badges?repo=owner/name
+ *
+ * Returns a markdown row of shields.io tech badges derived from the repo's
+ * primary language and topics. Responds 200 with an empty body when no tech
+ * is detected.
+ */
+export default async (req, res) => {
+    const parsed = parseRepo(req.query.repo);
+    if (!parsed) {
+        return res.status(400).type('text/plain').send('Missing or malformed `repo` (expected owner/name)');
+    }
+
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+
+    try {
+        const token = req.session?.github_token ?? process.env.GITHUB_TOKEN;
+        const meta  = await fetchRepoMeta(parsed.owner, parsed.name, token);
+        if (!meta) return res.status(404).type('text/plain').send(`Repo not found: ${parsed.owner}/${parsed.name}`);
+
+        return res.send(techBadges(meta));
+    } catch (err) {
+        return res.status(502).type('text/plain').send(`Failed to fetch repo: ${err.message}`);
+    }
+};
+
+// Route descriptor for the auto-mounting registry (#52). When the registry
+// lands, this handler mounts at GET /repo-tech-badges with no express.js edit.
+export const route = { method: 'get', path: '/repo-tech-badges', auth: false };
+
+export { parseRepo };

--- a/src/markdown/tech-badges.js
+++ b/src/markdown/tech-badges.js
@@ -1,0 +1,70 @@
+import { TAXONOMY } from '../data/tech-taxonomy.js';
+import { lookupIcon } from '../github/tech-data.js';
+
+/**
+ * Encodes a label for a shields.io static badge path segment.
+ * Per shields.io rules: `_` → `__`, `-` → `--`, space → `_`, then URL-encode.
+ *
+ * @param {string} label
+ * @returns {string}
+ */
+const encodeBadgeLabel = (label) =>
+    encodeURIComponent(label.replace(/_/g, '__').replace(/-/g, '--').replace(/ /g, '_'));
+
+/**
+ * Builds the shields.io markdown for a single tech, attaching the simple-icons
+ * logo + brand colour when one is known. Falls back to a neutral grey badge
+ * with no logo for techs that have no matching icon.
+ *
+ * @param {string} displayName  Human-facing tech name (e.g. "PostgreSQL")
+ * @returns {string} shields.io badge markdown
+ */
+const badgeFor = (displayName) => {
+    const icon  = lookupIcon(displayName);
+    const color = icon ? icon.hex : '555555';
+    const label = encodeBadgeLabel(displayName);
+    const logo  = icon ? `&logo=${icon.slug}&logoColor=white` : '';
+    const url   = `https://img.shields.io/badge/${label}-${color}?style=for-the-badge${logo}`;
+    return `![${displayName}](${url})`;
+};
+
+/**
+ * Maps a repository's detected languages and topics to a row of shields.io
+ * tech badges (markdown). Languages come first (in the order supplied), then
+ * topic-derived techs resolved through the shared tech-taxonomy. Duplicates
+ * (case-insensitive on display name) are collapsed, preserving first occurrence.
+ *
+ * @param {object}   repo
+ * @param {string}   [repo.language]   Primary language from the REST repo object
+ * @param {string[]} [repo.languages]  Optional full language list (overrides `language`)
+ * @param {string[]} [repo.topics]     GitHub topic slugs
+ * @returns {string} Markdown badge row, or '' when no tech is detected
+ */
+export const techBadges = ({ language, languages, topics = [] } = {}) => {
+    const names = [];
+    const seen  = new Set();
+    const push  = (name) => {
+        if (!name) return;
+        const key = name.toLowerCase();
+        if (seen.has(key)) return;
+        seen.add(key);
+        names.push(name);
+    };
+
+    // Languages first, in the order supplied.
+    const langList = Array.isArray(languages) && languages.length ? languages : (language ? [language] : []);
+    langList.forEach(push);
+
+    // Topics resolved through the taxonomy → display names.
+    (topics || []).forEach((topic) => {
+        const entry = TAXONOMY[String(topic).toLowerCase()];
+        if (entry) push(entry.displayName);
+    });
+
+    if (names.length === 0) return '';
+
+    return names.map(badgeFor).join(' ');
+};
+
+export { encodeBadgeLabel, badgeFor };
+export default techBadges;

--- a/src/tests/repo-card.test.js
+++ b/src/tests/repo-card.test.js
@@ -1,0 +1,162 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { renderRepoCard, formatCount, relativeTime } from '../tiles/repo-card.js';
+import handler, { toCardData, parseRepo } from '../../api/repo-card.js';
+
+describe('formatCount', () => {
+    test('passes through small numbers', () => {
+        expect(formatCount(0)).toBe('0');
+        expect(formatCount(999)).toBe('999');
+    });
+    test('abbreviates thousands and millions', () => {
+        expect(formatCount(1200)).toBe('1.2k');
+        expect(formatCount(12000)).toBe('12k');
+        expect(formatCount(1_500_000)).toBe('1.5m');
+    });
+});
+
+describe('relativeTime', () => {
+    const NOW = new Date('2026-06-01T00:00:00Z').getTime();
+    test('today / yesterday / days', () => {
+        expect(relativeTime('2026-06-01T00:00:00Z', NOW)).toBe('updated today');
+        expect(relativeTime('2026-05-31T00:00:00Z', NOW)).toBe('updated yesterday');
+        expect(relativeTime('2026-05-20T00:00:00Z', NOW)).toBe('updated 12 days ago');
+    });
+    test('months and years', () => {
+        expect(relativeTime('2026-03-01T00:00:00Z', NOW)).toContain('month');
+        expect(relativeTime('2024-01-01T00:00:00Z', NOW)).toContain('year');
+    });
+    test('empty / invalid input yields empty string', () => {
+        expect(relativeTime('', NOW)).toBe('');
+        expect(relativeTime('not-a-date', NOW)).toBe('');
+    });
+});
+
+describe('renderRepoCard', () => {
+    const NOW = new Date('2026-06-01T00:00:00Z').getTime();
+    const repo = {
+        owner: 'octocat', name: 'hello-world',
+        description: 'My first repository on GitHub!',
+        stars: 1820, forks: 305, openIssues: 12,
+        language: 'JavaScript', languageHex: 'f1e05a',
+        updatedAt: '2026-05-28T00:00:00Z',
+    };
+
+    test('returns a well-formed SVG document', () => {
+        const svg = renderRepoCard(repo, { now: NOW });
+        expect(svg.startsWith('<svg')).toBe(true);
+        expect(svg.trimEnd().endsWith('</svg>')).toBe(true);
+        expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+    });
+
+    test('includes owner, name and stat values', () => {
+        const svg = renderRepoCard(repo, { now: NOW });
+        expect(svg).toContain('octocat');
+        expect(svg).toContain('hello-world');
+        expect(svg).toContain('1.8k');   // stars
+        expect(svg).toContain('305');    // forks
+        expect(svg).toContain('JavaScript');
+        expect(svg).toContain('updated 4 days ago');
+    });
+
+    test('escapes XML-unsafe characters in description', () => {
+        const svg = renderRepoCard({ ...repo, description: 'a & b <script>' }, { now: NOW });
+        expect(svg).toContain('a &amp; b &lt;script&gt;');
+        expect(svg).not.toContain('<script>');
+    });
+
+    test('omits the language row when no language is present', () => {
+        const svg = renderRepoCard({ ...repo, language: '' }, { now: NOW });
+        expect(svg).not.toContain('JavaScript');
+    });
+
+    test('shows a fallback when description is empty', () => {
+        const svg = renderRepoCard({ ...repo, description: '' }, { now: NOW });
+        expect(svg).toContain('No description provided.');
+    });
+});
+
+describe('toCardData', () => {
+    test('maps the REST repo object to the renderer shape', () => {
+        const data = {
+            owner: { login: 'octocat' }, name: 'hello-world',
+            description: 'hi', stargazers_count: 5, forks_count: 2,
+            open_issues_count: 1, language: 'Go',
+            pushed_at: '2026-05-30T00:00:00Z',
+        };
+        const card = toCardData(data);
+        expect(card.owner).toBe('octocat');
+        expect(card.stars).toBe(5);
+        expect(card.forks).toBe(2);
+        expect(card.openIssues).toBe(1);
+        expect(card.language).toBe('Go');
+        expect(card.languageHex).toMatch(/^[0-9a-fA-F]{6}$/); // resolved from simple-icons
+        expect(card.updatedAt).toBe('2026-05-30T00:00:00Z');
+    });
+
+    test('falls back to neutral hex for an unknown language', () => {
+        const card = toCardData({ owner: { login: 'x' }, name: 'y', language: 'Brainfuck' });
+        expect(card.languageHex).toBe('8b949e');
+    });
+});
+
+describe('GET /repo-card handler', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    const mockRes = () => ({
+        statusCode: 200,
+        headers: {},
+        body: undefined,
+        status(c) { this.statusCode = c; return this; },
+        type() { return this; },
+        setHeader(k, v) { this.headers[k] = v; },
+        send(b) { this.body = b; return this; },
+    });
+
+    test('400 on missing/malformed repo param', async () => {
+        const res = mockRes();
+        await handler({ query: {} }, res);
+        expect(res.statusCode).toBe(400);
+    });
+
+    test('404 when the repo is missing', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404 })));
+        const res = mockRes();
+        await handler({ query: { repo: 'octocat/missing' } }, res);
+        expect(res.statusCode).toBe(404);
+    });
+
+    test('renders an SVG card for a valid repo', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => ({
+            ok: true,
+            json: async () => ({
+                owner: { login: 'octocat' }, name: 'hello-world',
+                description: 'hi', stargazers_count: 10, forks_count: 3,
+                open_issues_count: 0, language: 'Python', pushed_at: '2026-05-31T00:00:00Z',
+            }),
+        })));
+        const res = mockRes();
+        await handler({ query: { repo: 'octocat/hello-world' } }, res);
+        expect(res.statusCode).toBe(200);
+        expect(res.headers['Content-Type']).toBe('image/svg+xml');
+        expect(res.body).toContain('<svg');
+        expect(res.body).toContain('hello-world');
+    });
+
+    test('502 when the fetch throws', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+        const res = mockRes();
+        await handler({ query: { repo: 'octocat/hello-world' } }, res);
+        expect(res.statusCode).toBe(502);
+    });
+});
+
+describe('route descriptor', () => {
+    test('exposes {method, path, auth}', async () => {
+        const { route } = await import('../../api/repo-card.js');
+        expect(route).toMatchObject({ method: 'get', path: '/repo-card', auth: false });
+    });
+    test('parseRepo handles owner/name', () => {
+        expect(parseRepo('a/b')).toEqual({ owner: 'a', name: 'b' });
+        expect(parseRepo('bad')).toBeNull();
+    });
+});

--- a/src/tests/tech-badges.test.js
+++ b/src/tests/tech-badges.test.js
@@ -1,0 +1,130 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { techBadges, encodeBadgeLabel } from '../markdown/tech-badges.js';
+import handler, { parseRepo } from '../../api/repo-tech-badges.js';
+
+describe('encodeBadgeLabel', () => {
+    test('escapes shields.io special characters', () => {
+        expect(encodeBadgeLabel('C++')).toBe('C%2B%2B');
+        expect(encodeBadgeLabel('a-b')).toBe('a--b');
+        expect(encodeBadgeLabel('a_b')).toBe('a__b');
+        expect(encodeBadgeLabel('Spring Boot')).toBe('Spring_Boot');
+    });
+});
+
+describe('techBadges', () => {
+    test('returns empty string when no tech is detected', () => {
+        expect(techBadges({})).toBe('');
+        expect(techBadges({ language: '', topics: [] })).toBe('');
+    });
+
+    test('emits a badge for the primary language', () => {
+        const md = techBadges({ language: 'TypeScript', topics: [] });
+        expect(md).toContain('![TypeScript]');
+        expect(md).toContain('img.shields.io/badge/TypeScript');
+        expect(md).toContain('logo=typescript');
+    });
+
+    test('maps known topics through the taxonomy to display names', () => {
+        const md = techBadges({ language: 'Python', topics: ['fastapi', 'postgres'] });
+        expect(md).toContain('![Python]');
+        expect(md).toContain('![FastAPI]');
+        expect(md).toContain('![PostgreSQL]');
+    });
+
+    test('ignores unknown topics', () => {
+        const md = techBadges({ language: 'Go', topics: ['some-random-topic'] });
+        expect(md).toContain('![Go]');
+        expect(md).not.toContain('some-random-topic');
+    });
+
+    test('deduplicates techs case-insensitively', () => {
+        // `react` and `reactjs` both map to "React"
+        const md = techBadges({ language: 'JavaScript', topics: ['react', 'reactjs'] });
+        expect(md.match(/!\[React\]/g)).toHaveLength(1);
+    });
+
+    test('falls back to a neutral badge with no logo for unknown tech', () => {
+        const md = techBadges({ language: 'Brainfuck', topics: [] });
+        expect(md).toContain('![Brainfuck]');
+        expect(md).toContain('-555555?');
+        expect(md).not.toContain('logo=');
+    });
+
+    test('prefers the languages array when supplied', () => {
+        const md = techBadges({ languages: ['Rust', 'Go'], language: 'Ignored', topics: [] });
+        expect(md).toContain('![Rust]');
+        expect(md).toContain('![Go]');
+        expect(md).not.toContain('![Ignored]');
+    });
+});
+
+describe('GET /repo-tech-badges handler', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    const mockRes = () => {
+        const res = {
+            statusCode: 200,
+            headers: {},
+            body: undefined,
+            status(c) { this.statusCode = c; return this; },
+            type() { return this; },
+            setHeader(k, v) { this.headers[k] = v; },
+            send(b) { this.body = b; return this; },
+        };
+        return res;
+    };
+
+    test('400 on missing repo param', async () => {
+        const res = mockRes();
+        await handler({ query: {} }, res);
+        expect(res.statusCode).toBe(400);
+    });
+
+    test('400 on malformed repo param', async () => {
+        const res = mockRes();
+        await handler({ query: { repo: 'not-a-slug' } }, res);
+        expect(res.statusCode).toBe(400);
+    });
+
+    test('404 when GitHub reports the repo missing', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404 })));
+        const res = mockRes();
+        await handler({ query: { repo: 'octocat/missing' } }, res);
+        expect(res.statusCode).toBe(404);
+    });
+
+    test('returns a badge row for a valid repo', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => ({
+            ok: true,
+            json: async () => ({ language: 'TypeScript', topics: ['react'] }),
+        })));
+        const res = mockRes();
+        await handler({ query: { repo: 'octocat/web' } }, res);
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toContain('![TypeScript]');
+        expect(res.body).toContain('![React]');
+        expect(res.headers['Content-Type']).toContain('text/plain');
+    });
+
+    test('200 with empty body when repo has no detectable tech', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => ({
+            ok: true,
+            json: async () => ({ language: null, topics: [] }),
+        })));
+        const res = mockRes();
+        await handler({ query: { repo: 'octocat/empty' } }, res);
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toBe('');
+    });
+
+    test('exports a valid route descriptor', () => {
+        expect(parseRepo('a/b')).toEqual({ owner: 'a', name: 'b' });
+    });
+});
+
+describe('route descriptor', () => {
+    test('exposes {method, path, auth}', async () => {
+        const { route } = await import('../../api/repo-tech-badges.js');
+        expect(route).toMatchObject({ method: 'get', path: '/repo-tech-badges', auth: false });
+    });
+});

--- a/src/tiles/repo-card.js
+++ b/src/tiles/repo-card.js
@@ -1,0 +1,124 @@
+import { THEME_CSS } from './theme.js';
+
+// ── Octicon path data (16×16 viewBox) ──────────────────────────────────────
+const ICON_REPO  = 'M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z';
+const ICON_STAR  = 'M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z';
+const ICON_FORK  = 'M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z';
+const ICON_ISSUE = 'M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z';
+
+const escapeXml = (s) =>
+    String(s ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+
+const clamp = (str, max) => (str.length > max ? str.slice(0, max - 1).trimEnd() + '…' : str);
+
+/** Formats a count compactly: 1234 → "1.2k", 12000 → "12k". */
+const formatCount = (n) => {
+    const num = Number(n) || 0;
+    if (num < 1000) return String(num);
+    if (num < 1_000_000) {
+        const k = num / 1000;
+        return (k >= 10 ? Math.round(k) : k.toFixed(1).replace(/\.0$/, '')) + 'k';
+    }
+    const m = num / 1_000_000;
+    return (m >= 10 ? Math.round(m) : m.toFixed(1).replace(/\.0$/, '')) + 'm';
+};
+
+/**
+ * Human-readable "last updated" relative to now.
+ * @param {string|number|Date} updatedAt  ISO string / epoch ms / Date
+ * @param {number} now  reference time in epoch ms (injected for testability)
+ */
+const relativeTime = (updatedAt, now) => {
+    if (!updatedAt) return '';
+    const then = new Date(updatedAt).getTime();
+    if (Number.isNaN(then)) return '';
+    const days = Math.floor((now - then) / 86_400_000);
+    if (days <= 0) return 'updated today';
+    if (days === 1) return 'updated yesterday';
+    if (days < 30) return `updated ${days} days ago`;
+    const months = Math.floor(days / 30);
+    if (months < 12) return `updated ${months} month${months === 1 ? '' : 's'} ago`;
+    const years = Math.floor(days / 365);
+    return `updated ${years} year${years === 1 ? '' : 's'} ago`;
+};
+
+const W = 460;
+const H = 200;
+const PAD = 22;
+
+/** Renders a small octicon glyph + its value as one stat group at (x, y). */
+const stat = (x, y, path, value) => `
+    <g transform="translate(${x}, ${y})">
+        <g transform="scale(0.875)" fill="var(--fg60)"><path fill-rule="evenodd" d="${path}"/></g>
+        <text x="22" y="11" font-size="13" font-family="Arial, sans-serif" fill="var(--fg75)">${escapeXml(value)}</text>
+    </g>`;
+
+/**
+ * Renders a repository summary card as a self-contained, theme-aware SVG.
+ * Light/dark is handled by THEME_CSS via prefers-color-scheme — no theme arg.
+ *
+ * @param {object} repo
+ * @param {string} repo.owner
+ * @param {string} repo.name
+ * @param {string} [repo.description]
+ * @param {number} [repo.stars]
+ * @param {number} [repo.forks]
+ * @param {number} [repo.openIssues]
+ * @param {string} [repo.language]
+ * @param {string} [repo.languageHex]  hex (no '#') for the language dot
+ * @param {string} [repo.updatedAt]    ISO timestamp
+ * @param {object} [opts]
+ * @param {number} [opts.now]  reference time (epoch ms); defaults to Date.now()
+ * @returns {string} SVG document
+ */
+export const renderRepoCard = (repo = {}, opts = {}) => {
+    const {
+        owner = '', name = '', description = '',
+        stars = 0, forks = 0, openIssues = 0,
+        language = '', languageHex = '8b949e', updatedAt = '',
+    } = repo;
+    const now = opts.now ?? Date.now();
+
+    const title = `${escapeXml(owner)} / <tspan font-weight="700">${escapeXml(clamp(name, 28))}</tspan>`;
+    const desc  = clamp(description || 'No description provided.', 64);
+
+    const statsY = 132;
+    const stats = [
+        stat(PAD, statsY, ICON_STAR, formatCount(stars)),
+        stat(PAD + 92, statsY, ICON_FORK, formatCount(forks)),
+        stat(PAD + 184, statsY, ICON_ISSUE, formatCount(openIssues)),
+    ].join('');
+
+    const langRow = language
+        ? `<g transform="translate(${PAD}, 166)">
+            <circle cx="6" cy="6" r="6" fill="#${escapeXml(languageHex)}"/>
+            <text x="20" y="11" font-size="13" font-family="Arial, sans-serif" fill="var(--fg75)">${escapeXml(language)}</text>
+        </g>`
+        : '';
+
+    const updated = relativeTime(updatedAt, now);
+    const updatedRow = updated
+        ? `<text x="${W - PAD}" y="177" text-anchor="end" font-size="12" font-family="Arial, sans-serif" fill="var(--fg40)">${escapeXml(updated)}</text>`
+        : '';
+
+    return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="${escapeXml(owner)}/${escapeXml(name)} repository card">
+    ${THEME_CSS}
+    <rect x="0.5" y="0.5" width="${W - 1}" height="${H - 1}" rx="12" fill="var(--bg2)" stroke="var(--fg15)"/>
+    <g transform="translate(${PAD}, 30)">
+        <g transform="scale(1.1)" fill="var(--fg60)"><path fill-rule="evenodd" d="${ICON_REPO}"/></g>
+        <text x="28" y="14" font-size="18" font-family="Arial, sans-serif" fill="var(--fg85)">${title}</text>
+    </g>
+    <text x="${PAD}" y="86" font-size="14" font-family="Arial, sans-serif" fill="var(--fg60)">${escapeXml(desc)}</text>
+    <line x1="${PAD}" y1="108" x2="${W - PAD}" y2="108" stroke="var(--fg10)"/>
+    ${stats}
+    ${langRow}
+    ${updatedRow}
+</svg>`;
+};
+
+export { formatCount, relativeTime, clamp, escapeXml };
+export default renderRepoCard;


### PR DESCRIPTION
Stream **repo-components** — Phase 2 new components.

Closes #43 and #44.

## #43 — Tech-stack badge row generator + endpoint
- `src/markdown/tech-badges.js` maps a repo's primary language and topics (via the shared `tech-taxonomy`) to a row of shields.io badge markdown, with simple-icons logos + brand colours and a neutral fallback for unknown tech.
- `GET /repo-tech-badges?repo=owner/name` returns the badge row as `text/plain`; 200 with empty body when no tech is detected.

## #44 — Repo stats SVG card component + endpoint
- `src/tiles/repo-card.js` renders a self-contained, theme-aware SVG card (stars, forks, open issues, primary language, last-updated) with octicon glyphs and light/dark via `THEME_CSS`.
- `GET /repo-card?repo=owner/name` sources data from the REST repo object and resolves the language colour from simple-icons.

## Route registration
Both handlers export a `{method, path, auth}` **route descriptor** for the auto-mounting registry (#52) and make **no edit to `express.js`**, per the acceptance criteria. #52 (`core-http`) has not landed yet, so end-to-end auto-mount is verified once that registry merges; until then the descriptor export is inert and harmless.

## Tests
- `src/tests/tech-badges.test.js` (15) and `src/tests/repo-card.test.js` (18): unit coverage for the generators/renderer plus handler-level tests (param validation, 400/404/502, success) using a stubbed `fetch`.
- Full suite: **52 passed**. `npm run lint`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)