### PR TITLE
refactor: injectable/mockable AI + GitHub client layers (#49, #50)

### DIFF
--- a/src/ai/client.js
+++ b/src/ai/client.js
@@ -1,0 +1,43 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+/**
+ * Single source of truth for the Google Gemini client.
+ *
+ * The whole AI layer (model.js, repo-analyzer.js, …) obtains its generative
+ * model from here instead of each module constructing its own
+ * `GoogleGenerativeAI`. Construction is lazy — importing this module performs no
+ * network access and does not require `GOOGLE_AI_STUDIO_KEY` to be set — so unit
+ * tests can import AI consumers and inject a fake model without touching the
+ * network.
+ */
+
+export const DEFAULT_MODEL = 'gemini-2.5-flash';
+
+/**
+ * Creates a fresh GoogleGenerativeAI client.
+ *
+ * @param {string} [apiKey] Gemini API key; defaults to GOOGLE_AI_STUDIO_KEY.
+ * @returns {import('@google/generative-ai').GoogleGenerativeAI}
+ */
+export const createAiClient = (apiKey = process.env.GOOGLE_AI_STUDIO_KEY) =>
+    new GoogleGenerativeAI(apiKey);
+
+let sharedClient;
+
+/**
+ * Returns the process-wide shared client, creating it on first use.
+ * @returns {import('@google/generative-ai').GoogleGenerativeAI}
+ */
+export const getAiClient = () => (sharedClient ??= createAiClient());
+
+/**
+ * Resolves a generative model from the shared client.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.model]            model id (default: gemini-2.5-flash)
+ * @param {object} [opts.generationConfig] passed through to getGenerativeModel
+ * @param {object} [opts.client]           inject a client (tests); defaults to shared
+ * @returns {object} a model exposing `generateContent`
+ */
+export const getModel = ({ model = DEFAULT_MODEL, generationConfig, client = getAiClient() } = {}) =>
+    client.getGenerativeModel(generationConfig ? { model, generationConfig } : { model });

--- a/src/ai/model.js
+++ b/src/ai/model.js
@@ -1,15 +1,20 @@
-import { GoogleGenerativeAI } from "@google/generative-ai";
+import { getModel } from './client.js';
 
-const googleAIStudioKey = process.env.GOOGLE_AI_STUDIO_KEY;
-const prompt = process.env.AI_PROMPT;
-const genAI = new GoogleGenerativeAI(googleAIStudioKey);
-const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
-
-const generateTopicsSummary = (repos) => {
-    return model.generateContent(prompt.replace(/\{topics\}/g, JSON.stringify(repos)))
-        .then(data => data.response.text())
-        .catch(err => { throw err; });
-}
+/**
+ * Summarizes a set of repos via Gemini using the AI_PROMPT template.
+ *
+ * @param {Array}  repos   repo data substituted into the `{topics}` placeholder
+ * @param {object} [model] injected generative model; defaults to the shared
+ *                         client's model (see ./client.js). Inject a fake in
+ *                         unit tests to avoid any network access.
+ * @returns {Promise<string>} the generated summary text
+ */
+const generateTopicsSummary = (repos, model = getModel()) => {
+    const prompt = process.env.AI_PROMPT;
+    return model
+        .generateContent(prompt.replace(/\{topics\}/g, JSON.stringify(repos)))
+        .then((data) => data.response.text());
+};
 
 export { generateTopicsSummary };
 export default generateTopicsSummary;

--- a/src/ai/repo-analyzer.js
+++ b/src/ai/repo-analyzer.js
@@ -1,11 +1,9 @@
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { getModel } from './client.js';
 
-const genAI = new GoogleGenerativeAI(process.env.GOOGLE_AI_STUDIO_KEY);
-
-const model = genAI.getGenerativeModel({
-    model: 'gemini-2.5-flash',
-    generationConfig: { responseMimeType: 'application/json' },
-});
+// JSON-mode model used for the qualitative pass. Resolved lazily (at call time,
+// via analyzeRepo's default param) so importing this module needs no API key
+// and performs no network access — keeping unit tests offline.
+const jsonModel = () => getModel({ generationConfig: { responseMimeType: 'application/json' } });
 
 // ── Scoring helpers (deterministic pre-pass) ───────────────────────────────────
 
@@ -215,9 +213,11 @@ const buildContext = (snapshot) => {
  * qualitative assessment, suggested topics, and README outline.
  *
  * @param {object} snapshot  Result of getRepoSnapshot()
+ * @param {object} [model]   injected generative model (defaults to the shared
+ *                           JSON-mode client model); inject a fake in tests.
  * @returns {object}  Full analysis with codeQuality, suggestions, readmeOutline
  */
-export const analyzeRepo = async (snapshot) => {
+export const analyzeRepo = async (snapshot, model = jsonModel()) => {
     const { meta, signals, fileContents } = snapshot;
 
     // ── Deterministic scoring ──────────────────────────────────────────────────

--- a/src/github/repo-contents.js
+++ b/src/github/repo-contents.js
@@ -1,4 +1,4 @@
-const GH = 'https://api.github.com';
+import { createGithubClient } from './repos.js';
 
 // Config/manifest files that reveal the project's toolchain
 const KEY_FILES = [
@@ -74,17 +74,9 @@ const extOf = (path) => {
 
 const isSourceFile = (path) => SOURCE_EXTS.has(extOf(path)) && !isTestPath(path);
 
-const ghHeaders = (token) => ({
-    Authorization: `Bearer ${token}`,
-    Accept:        'application/vnd.github+json',
-});
-
-const readFile = async (token, owner, repo, path) => {
+const readFile = async (gh, owner, repo, path) => {
     try {
-        const res = await fetch(
-            `${GH}/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`,
-            { headers: ghHeaders(token) }
-        );
+        const res = await gh.request(`/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`);
         if (!res.ok) return null;
         const data = await res.json();
         if (Array.isArray(data) || data.encoding !== 'base64') return null;
@@ -99,21 +91,26 @@ const readFile = async (token, owner, repo, path) => {
  * Fetches a thorough snapshot of a repository for code quality analysis.
  * Makes ~25–30 GitHub API calls per repo.
  *
+ * @param {string} token       bearer token used to build a default client
+ * @param {string} owner
+ * @param {string} repoName
+ * @param {object} [client]    injected GitHub client (tests); defaults to a
+ *                             token-aware client (see createGithubClient)
  * @returns {{ meta, tree, signals, fileContents, sourceFiles, testFiles }}
  */
-export const getRepoSnapshot = async (token, owner, repoName) => {
-    const hdrs = ghHeaders(token);
+export const getRepoSnapshot = async (token, owner, repoName, client) => {
+    const gh = client ?? createGithubClient({ token });
 
     // ── 1. Repo metadata ───────────────────────────────────────────────────────
-    const metaRes = await fetch(`${GH}/repos/${owner}/${repoName}`, { headers: hdrs });
+    const metaRes = await gh.request(`/repos/${owner}/${repoName}`);
     if (!metaRes.ok) throw new Error(`Repo not found: ${owner}/${repoName}`);
     const meta = await metaRes.json();
     const branch = meta.default_branch || 'main';
 
     // ── 2. Full file tree ──────────────────────────────────────────────────────
-    const treeRes = await fetch(
-        `${GH}/repos/${owner}/${repoName}/git/trees/${branch}?recursive=1`,
-        { headers: hdrs }
+    const treeRes = await gh.request(
+        `/repos/${owner}/${repoName}/git/trees/${branch}`,
+        { params: { recursive: 1 } }
     );
     if (!treeRes.ok) throw new Error(`Tree fetch failed for ${repoName}`);
     const { tree: rawTree = [], truncated } = await treeRes.json();
@@ -152,7 +149,7 @@ export const getRepoSnapshot = async (token, owner, repoName) => {
     ].slice(0, 30); // hard cap to protect rate limits
 
     const readResults = await Promise.all(
-        toRead.map(async path => ({ path, content: await readFile(token, owner, repoName, path) }))
+        toRead.map(async path => ({ path, content: await readFile(gh, owner, repoName, path) }))
     );
 
     const fileContents = {};

--- a/src/github/repos.js
+++ b/src/github/repos.js
@@ -1,41 +1,109 @@
-import axios from 'axios';
+const GH_API = 'https://api.github.com';
 
-const getRepos = (username) => {
-    return axios.get(`https://api.github.com/users/${username}/repos`)
-        .then(data => {
-            return data.data;
-        })
-        .catch(err => {
-            console.error(err);
-            return null;
-        });
+/**
+ * Creates a token-aware GitHub API client.
+ *
+ * This is the single, consistent surface every GitHub call in the project flows
+ * through. The `fetchImpl` transport is injectable, so handlers and the github
+ * helpers can be unit-tested against a fake client with no live network access.
+ *
+ * @param {object}   [opts]
+ * @param {string}   [opts.token]     bearer token; defaults to GITHUB_TOKEN. When
+ *                                    absent the client makes unauthenticated calls.
+ * @param {Function} [opts.fetchImpl] fetch implementation (inject a fake in tests)
+ * @param {string}   [opts.baseUrl]   API base URL (default: https://api.github.com)
+ * @returns {{ token: string|undefined, headers: Function, request: Function, getJson: Function, get: Function }}
+ */
+export const createGithubClient = ({
+    token = process.env.GITHUB_TOKEN,
+    fetchImpl = fetch,
+    baseUrl = GH_API,
+} = {}) => {
+    const headers = (extra = {}) => ({
+        Accept: 'application/vnd.github+json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...extra,
+    });
+
+    const buildUrl = (path, params) => {
+        const url = new URL(path.startsWith('http') ? path : `${baseUrl}${path}`);
+        if (params) {
+            for (const [key, value] of Object.entries(params)) {
+                if (value !== undefined && value !== null) url.searchParams.set(key, String(value));
+            }
+        }
+        return url;
+    };
+
+    /**
+     * Low-level request returning the raw Response.
+     * @param {string} path           path (joined to baseUrl) or absolute URL
+     * @param {object} [opts]
+     * @param {object} [opts.params]  query params appended to the URL
+     */
+    const request = (path, { params, headers: extraHeaders, ...init } = {}) =>
+        fetchImpl(buildUrl(path, params), { ...init, headers: headers(extraHeaders) });
+
+    /**
+     * GET returning parsed JSON, or `null` when the response is not OK.
+     * Network/transport errors reject — callers that want a soft failure catch.
+     */
+    const getJson = async (path, opts) => {
+        const res = await request(path, opts);
+        if (!res.ok) return null;
+        return res.json();
+    };
+
+    return { token, headers, request, getJson, get: getJson };
 };
 
-const getContents = (username, repository, path) => {
-    return axios.get(`https://api.github.com/repos/${username}/${repository}/contents/${path}`)
-        .then(data => {
-            return data.data
-        })
-        .catch(err => {
-            console.error(err);
-            return null;
-        })
-}
+/** Lazily-created shared client built from the environment. */
+let sharedClient;
+const defaultClient = () => (sharedClient ??= createGithubClient());
 
-const getAllRepos = async (token) => {
+/**
+ * Fetches a user's public repositories.
+ * @param {string} username
+ * @param {object} [client] injected GitHub client (tests)
+ * @returns {Promise<Array|null>} repo objects, or null on any error
+ */
+const getRepos = (username, client = defaultClient()) =>
+    client.getJson(`/users/${username}/repos`).catch(() => null);
+
+/**
+ * Fetches the contents of a path within a repository.
+ * @param {string} username
+ * @param {string} repository
+ * @param {string} path
+ * @param {object} [client] injected GitHub client (tests)
+ * @returns {Promise<object|Array|null>} contents payload, or null on any error
+ */
+const getContents = (username, repository, path, client = defaultClient()) =>
+    client.getJson(`/repos/${username}/${repository}/contents/${path}`).catch(() => null);
+
+/**
+ * Fetches all repositories owned by the authenticated user (paginated).
+ * @param {string} [token]  bearer token; defaults to GITHUB_TOKEN
+ * @param {object} [client] injected GitHub client (tests)
+ * @returns {Promise<Array|null>} repo objects, or null when no token is available
+ * @throws on a non-OK GitHub response
+ */
+const getAllRepos = async (token, client) => {
     const authToken = token ?? process.env.GITHUB_TOKEN;
     if (!authToken) return null;
 
+    const gh = client ?? createGithubClient({ token: authToken });
     const repos = [];
     let page = 1;
 
     while (true) {
-        const response = await axios.get('https://api.github.com/user/repos', {
-            headers: { Authorization: `Bearer ${authToken}` },
+        const res = await gh.request('/user/repos', {
             params: { visibility: 'all', affiliation: 'owner', per_page: 100, page },
         });
-        repos.push(...response.data);
-        if (response.data.length < 100) break;
+        if (!res.ok) throw new Error(`GET /user/repos → ${res.status}`);
+        const batch = await res.json();
+        repos.push(...batch);
+        if (batch.length < 100) break;
         page++;
     }
 

--- a/src/tests/ai-client.test.js
+++ b/src/tests/ai-client.test.js
@@ -1,0 +1,100 @@
+import { describe, test, expect, vi } from 'vitest';
+import { createAiClient, getModel, DEFAULT_MODEL } from '../ai/client.js';
+import generateTopicsSummary, { generateTopicsSummary as named } from '../ai/model.js';
+import { analyzeRepo } from '../ai/repo-analyzer.js';
+
+// A minimal fake generative model. Records the prompt it was called with and
+// returns a canned response — never touches the network.
+const fakeModel = (text) => ({
+    calls: [],
+    generateContent(prompt) {
+        this.calls.push(prompt);
+        return Promise.resolve({ response: { text: () => text } });
+    },
+});
+
+describe('ai/client.js', () => {
+    test('getModel resolves a model from an injected client', () => {
+        const client = { getGenerativeModel: vi.fn(() => 'MODEL') };
+        const model = getModel({ client });
+        expect(model).toBe('MODEL');
+        expect(client.getGenerativeModel).toHaveBeenCalledWith({ model: DEFAULT_MODEL });
+    });
+
+    test('getModel forwards generationConfig when provided', () => {
+        const client = { getGenerativeModel: vi.fn(() => 'JSON_MODEL') };
+        getModel({ client, generationConfig: { responseMimeType: 'application/json' } });
+        expect(client.getGenerativeModel).toHaveBeenCalledWith({
+            model: DEFAULT_MODEL,
+            generationConfig: { responseMimeType: 'application/json' },
+        });
+    });
+
+    test('createAiClient does not require a key to construct', () => {
+        expect(() => createAiClient('test-key')).not.toThrow();
+    });
+});
+
+describe('ai/model.js generateTopicsSummary', () => {
+    test('substitutes {topics} into AI_PROMPT and returns the model text', async () => {
+        const prev = process.env.AI_PROMPT;
+        process.env.AI_PROMPT = 'Summarize: {topics}';
+        const model = fakeModel('a summary');
+
+        const result = await generateTopicsSummary([{ name: 'repo-a' }], model);
+
+        expect(result).toBe('a summary');
+        expect(model.calls[0]).toBe('Summarize: [{"name":"repo-a"}]');
+        process.env.AI_PROMPT = prev;
+    });
+
+    test('default and named exports are the same function', () => {
+        expect(generateTopicsSummary).toBe(named);
+    });
+});
+
+describe('ai/repo-analyzer.js analyzeRepo', () => {
+    const snapshot = {
+        meta: { owner: 'octocat', name: 'demo', description: 'd', language: 'JavaScript', topics: [], stars: 1, forks: 0, license: 'MIT' },
+        signals: {
+            hasTestDir: true, testFileCount: 2, sourceFileCount: 8, testRatio: 0.25,
+            workflowCount: 1, hasDockerfile: false, hasDeployConfig: false,
+            hasTypeScript: false, hasLinter: true, hasFormatter: true, hasCoverage: false,
+            hasDependabot: false, hasSecurityMd: false, hasReadme: true, hasContributing: false,
+            hasChangelog: false, hasLicense: true, hasGitignore: true, hasSrcDir: true,
+            hasDocsDir: false, hasMakefile: false, hasPreCommit: false, hasTsconfig: false,
+            totalFiles: 20, treeWasTruncated: false,
+        },
+        fileContents: { 'README.md': '# Demo\nInstallation and usage examples here.', 'package.json': '{}' },
+        tree: { paths: ['README.md', 'package.json', 'src/index.js'] },
+        sourceFiles: ['src/index.js'],
+        testFiles: [],
+    };
+
+    test('uses the injected model and returns parsed Gemini fields', async () => {
+        const geminiJson = JSON.stringify({
+            summary: 'A demo project.',
+            suggestedDescription: 'Demo',
+            suggestedTopics: ['demo'],
+            techStack: ['JavaScript'],
+            codeQualityNotes: { testing: 'ok' },
+            suggestions: ['Add coverage'],
+            readmeOutline: { title: 'Demo' },
+        });
+        const result = await analyzeRepo(snapshot, fakeModel(geminiJson));
+
+        expect(result.summary).toBe('A demo project.');
+        expect(result.suggestedTopics).toEqual(['demo']);
+        expect(result.codeQuality.overall).toBeGreaterThan(0);
+        expect(result.codeQuality.notes.testing).toBe('ok');
+    });
+
+    test('falls back to deterministic scoring when the model fails', async () => {
+        const brokenModel = { generateContent: () => Promise.reject(new Error('boom')) };
+        const result = await analyzeRepo(snapshot, brokenModel);
+
+        expect(result.geminiError).toBe('boom');
+        expect(result.codeQuality.overall).toBeGreaterThan(0);
+        expect(result.readmeOutline).toBeNull();
+    });
+});

--- a/src/tests/github-client.test.js
+++ b/src/tests/github-client.test.js
@@ -1,0 +1,148 @@
+import { describe, test, expect } from 'vitest';
+import { createGithubClient, getRepos, getContents, getAllRepos } from '../github/repos.js';
+import { getRepoSnapshot } from '../github/repo-contents.js';
+
+// Builds a fake fetch from a handler(url) -> { ok?, status?, body? }.
+// Records every requested URL so tests can assert on auth/pagination/paths.
+const fakeFetch = (handler) => {
+    const urls = [];
+    const fn = async (url) => {
+        const u = url.toString();
+        urls.push(u);
+        const { ok = true, status = 200, body = {} } = handler(u) ?? {};
+        return { ok, status, json: async () => body };
+    };
+    fn.urls = urls;
+    return fn;
+};
+
+describe('createGithubClient', () => {
+    test('sends a Bearer token when one is provided', () => {
+        const client = createGithubClient({ token: 'tok', fetchImpl: fakeFetch(() => ({})) });
+        expect(client.headers().Authorization).toBe('Bearer tok');
+        expect(client.headers().Accept).toBe('application/vnd.github+json');
+    });
+
+    test('omits Authorization when no token is available', () => {
+        const client = createGithubClient({ token: null, fetchImpl: fakeFetch(() => ({})) });
+        expect(client.headers().Authorization).toBeUndefined();
+    });
+
+    test('getJson returns parsed body on OK and null on non-OK', async () => {
+        const okClient = createGithubClient({ token: 't', fetchImpl: fakeFetch(() => ({ body: { hello: 'world' } })) });
+        expect(await okClient.getJson('/x')).toEqual({ hello: 'world' });
+
+        const badClient = createGithubClient({ token: 't', fetchImpl: fakeFetch(() => ({ ok: false, status: 404 })) });
+        expect(await badClient.getJson('/x')).toBeNull();
+    });
+
+    test('request appends query params to the URL', async () => {
+        const ff = fakeFetch(() => ({ body: [] }));
+        const client = createGithubClient({ token: 't', fetchImpl: ff });
+        await client.request('/user/repos', { params: { per_page: 100, page: 2 } });
+        expect(ff.urls[0]).toContain('per_page=100');
+        expect(ff.urls[0]).toContain('page=2');
+    });
+});
+
+describe('getRepos', () => {
+    test('returns the repo array from a fake client', async () => {
+        const client = createGithubClient({ fetchImpl: fakeFetch(() => ({ body: [{ name: 'a' }] })) });
+        expect(await getRepos('octocat', client)).toEqual([{ name: 'a' }]);
+    });
+
+    test('returns null on a non-OK response', async () => {
+        const client = createGithubClient({ fetchImpl: fakeFetch(() => ({ ok: false, status: 500 })) });
+        expect(await getRepos('octocat', client)).toBeNull();
+    });
+
+    test('returns null on a transport error', async () => {
+        const client = createGithubClient({ fetchImpl: () => Promise.reject(new Error('offline')) });
+        expect(await getRepos('octocat', client)).toBeNull();
+    });
+});
+
+describe('getContents', () => {
+    test('returns the contents payload from a fake client', async () => {
+        const client = createGithubClient({ fetchImpl: fakeFetch(() => ({ body: { path: 'README.md' } })) });
+        expect(await getContents('octocat', 'demo', 'README.md', client)).toEqual({ path: 'README.md' });
+    });
+});
+
+describe('getAllRepos', () => {
+    test('returns null when no token is available', async () => {
+        const prev = process.env.GITHUB_TOKEN;
+        delete process.env.GITHUB_TOKEN;
+        expect(await getAllRepos(undefined)).toBeNull();
+        if (prev !== undefined) process.env.GITHUB_TOKEN = prev;
+    });
+
+    test('paginates until a short page and aggregates results', async () => {
+        const page1 = Array.from({ length: 100 }, (_, i) => ({ name: `r${i}` }));
+        const page2 = [{ name: 'last' }];
+        const ff = fakeFetch((u) => ({ body: u.includes('page=2') ? page2 : page1 }));
+        const client = createGithubClient({ token: 't', fetchImpl: ff });
+
+        const all = await getAllRepos('t', client);
+        expect(all).toHaveLength(101);
+        expect(all[100].name).toBe('last');
+        expect(ff.urls).toHaveLength(2);
+    });
+
+    test('throws on a non-OK GitHub response', async () => {
+        const client = createGithubClient({ token: 't', fetchImpl: fakeFetch(() => ({ ok: false, status: 401 })) });
+        await expect(getAllRepos('t', client)).rejects.toThrow('401');
+    });
+});
+
+describe('getRepoSnapshot', () => {
+    const b64 = (s) => Buffer.from(s).toString('base64');
+    const snapshotFetch = () => fakeFetch((u) => {
+        if (u.includes('/git/trees/')) {
+            return {
+                body: {
+                    truncated: false,
+                    tree: [
+                        { type: 'blob', path: 'package.json' },
+                        { type: 'blob', path: 'src/index.js' },
+                        { type: 'blob', path: 'README.md' },
+                        { type: 'tree', path: 'src' },
+                    ],
+                },
+            };
+        }
+        if (u.includes('/contents/')) {
+            return { body: { encoding: 'base64', content: b64('file contents') } };
+        }
+        // repo metadata
+        return {
+            body: {
+                default_branch: 'main',
+                description: 'demo repo',
+                language: 'JavaScript',
+                topics: ['demo'],
+                stargazers_count: 5,
+                forks_count: 1,
+                size: 10,
+                license: { spdx_id: 'MIT' },
+                visibility: 'public',
+            },
+        };
+    });
+
+    test('builds a snapshot from an injected client (no network)', async () => {
+        const client = createGithubClient({ token: 't', fetchImpl: snapshotFetch() });
+        const snap = await getRepoSnapshot('t', 'octocat', 'demo', client);
+
+        expect(snap.meta.owner).toBe('octocat');
+        expect(snap.meta.name).toBe('demo');
+        expect(snap.meta.license).toBe('MIT');
+        expect(snap.signals.totalFiles).toBe(3); // 3 blobs, the tree node excluded
+        expect(snap.fileContents['package.json']).toBe('file contents');
+    });
+
+    test('throws when the repo metadata request is not OK', async () => {
+        const client = createGithubClient({ token: 't', fetchImpl: fakeFetch(() => ({ ok: false, status: 404 })) });
+        await expect(getRepoSnapshot('t', 'octocat', 'missing', client)).rejects.toThrow('Repo not found');
+    });
+});


### PR DESCRIPTION
Closes #49 and #50 (Phase 1 · stream `core-clients`).

## What
Make the AI (Gemini) and GitHub client layers injectable so handlers/analyzers can be unit-tested against fakes with no live network.

### AI layer (#49)
- **New `src/ai/client.js`** — single source of truth for the Gemini client. Lazy + injectable; importing it performs no network access and needs no API key.
- `model.js` — `generateTopicsSummary(repos, model?)` accepts an injected model (defaults to the shared client); reads `AI_PROMPT` at call time.
- `repo-analyzer.js` — `analyzeRepo(snapshot, model?)` accepts an injected model and resolves the shared JSON-mode model lazily instead of `new GoogleGenerativeAI` at import.

### GitHub layer (#50)
- `repos.js` — new `createGithubClient({ token, fetchImpl, baseUrl })`: a consistent, **token-aware** surface with an **injectable transport**. `getRepos` / `getContents` / `getAllRepos` flow through it.
- `repo-contents.js` — `getRepoSnapshot(token, owner, repo, client?)` accepts an injected client (defaults to a token-aware client); identical URLs/behavior.

## Behavior preserved
- `getRepos`/`getContents` still return `null` on any error; `getAllRepos` still returns `null` without a token and throws on a non-OK response. All consumer call-sites (`account-summary`, `repo-scan`, `repo-apply`, `apply-all`, tech-* endpoints) use the existing signatures — the new params are optional.

## Acceptance criteria
**#49** — ✅ single `src/ai/client.js` creates the Gemini client · ✅ `model.js` accepts an injected client · ✅ handlers/analyzer import the shared client; no network in unit tests
**#50** — ✅ consistent token-aware GitHub client surface · ✅ handlers unit-test against a fake client (no live network) · ✅ existing endpoints unchanged in behavior

## Tests
Added offline unit tests: `src/tests/ai-client.test.js`, `src/tests/github-client.test.js`. Full suite **39 passed** (was 19); `npm run lint` clean (0 errors).

Note: `repo-analyzer.js` is in the `src/ai/` layer but not in #49's literal `owns` list — touched only to point it at the shared client per the acceptance criterion (logged via `bsc-note`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)