### PR TITLE
feat: add /social-links and /language-trend components (#40, #41)

### DIFF
--- a/api/language-trend.js
+++ b/api/language-trend.js
@@ -1,0 +1,137 @@
+import { renderLanguageTrend } from '../src/tiles/language-trend.js';
+import { getAllRepos } from '../src/github/repos.js';
+import LANGUAGE_ICON_MAP from '../src/icons/languages.js';
+import * as simpleIcons from 'simple-icons';
+
+const REPO_CAP_DEFAULT = 40;   // max repos to fetch /languages for (bounds API calls)
+const LANG_LIMIT_DEFAULT = 6;  // max languages shown as stacked series
+const CACHE_TTL_MS = 15 * 60 * 1000;
+
+/** username|repoCap|langLimit → { svg, ts } */
+const cache = new Map();
+
+const normalizeForSlug = (lang) => lang.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+/** Brand colour for a language, mirroring the lookup used by /tech-chart. */
+const hexFor = (lang) => {
+    if (LANGUAGE_ICON_MAP[lang]) return LANGUAGE_ICON_MAP[lang].hex;
+    const key = `si${normalizeForSlug(lang).replace(/^./, c => c.toUpperCase())}`;
+    return simpleIcons[key]?.hex ?? null;
+};
+
+const ghHeaders = (token) => ({
+    Authorization: `Bearer ${token}`,
+    Accept:        'application/vnd.github+json',
+});
+
+/** Fetches the language→bytes breakdown for one repo; tolerates failures. */
+const fetchLanguages = async (owner, repo, token) => {
+    try {
+        const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/languages`, {
+            headers: ghHeaders(token),
+        });
+        return res.ok ? await res.json() : {};
+    } catch {
+        return {};
+    }
+};
+
+/**
+ * Builds the cumulative stacked-area dataset from a set of repos:
+ *  1. cap to the largest `repoCap` non-fork repos (bounds /languages calls),
+ *  2. bucket each repo's language bytes by its creation year,
+ *  3. fill the year range contiguously and prefix-sum into cumulative totals,
+ *  4. keep the top `langLimit` languages by total bytes.
+ */
+const buildDataset = async (repos, token, repoCap, langLimit) => {
+    const selected = repos
+        .filter(r => !r.fork)
+        .sort((a, b) => (b.size ?? 0) - (a.size ?? 0))
+        .slice(0, repoCap);
+
+    if (selected.length === 0) return { buckets: [], series: [] };
+
+    // year → { language → bytes }
+    const perYear = new Map();
+    const totals = {};
+
+    const breakdowns = await Promise.all(
+        selected.map(r => fetchLanguages(r.owner.login, r.name, token)),
+    );
+
+    selected.forEach((repo, i) => {
+        const year = new Date(repo.created_at).getUTCFullYear();
+        if (!perYear.has(year)) perYear.set(year, {});
+        const bucket = perYear.get(year);
+        for (const [lang, bytes] of Object.entries(breakdowns[i])) {
+            bucket[lang] = (bucket[lang] ?? 0) + bytes;
+            totals[lang] = (totals[lang] ?? 0) + bytes;
+        }
+    });
+
+    const topLangs = Object.entries(totals)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, langLimit)
+        .map(([lang]) => lang);
+
+    if (topLangs.length === 0) return { buckets: [], series: [] };
+
+    // Contiguous year range so the stacked area has no gaps.
+    const years = [...perYear.keys()].sort((a, b) => a - b);
+    const buckets = [];
+    for (let y = years[0]; y <= years[years.length - 1]; y++) buckets.push(y);
+
+    const series = topLangs.map((lang) => {
+        let running = 0;
+        const values = buckets.map((y) => {
+            running += perYear.get(y)?.[lang] ?? 0;
+            return running;
+        });
+        return { language: lang, hex: hexFor(lang), values };
+    });
+
+    return { buckets: buckets.map(String), series };
+};
+
+/**
+ * GET /language-trend
+ *
+ * Approximates how a user's language usage has grown over time by bucketing each
+ * repository's language bytes by its creation year and rendering a cumulative
+ * stacked-area chart. Results are cached for 15 minutes per user to limit the
+ * fan-out of per-repo /languages calls.
+ *
+ * Query: ?repos=<N> (repo cap, default 40), ?limit=<N> (languages, default 6),
+ *        ?username=<login> (cache key when unauthenticated).
+ */
+export default async (req, res) => {
+    res.setHeader('Content-Type', 'image/svg+xml');
+
+    const repoCap   = Math.max(1, parseInt(req.query.repos, 10) || REPO_CAP_DEFAULT);
+    const langLimit = Math.max(1, parseInt(req.query.limit, 10) || LANG_LIMIT_DEFAULT);
+    const token     = req.session?.github_token ?? process.env.GITHUB_TOKEN;
+    const username  = req.session?.github_username ?? req.query.username ?? 'env';
+
+    try {
+        const repos = await getAllRepos(token);
+        if (!repos) return res.status(401).send('GitHub not connected');
+
+        const cacheKey = `${username}|${repoCap}|${langLimit}`;
+        const hit = cache.get(cacheKey);
+        if (hit && Date.now() - hit.ts < CACHE_TTL_MS) return res.send(hit.svg);
+
+        const dataset = await buildDataset(repos, token, repoCap, langLimit);
+        const svg = renderLanguageTrend(dataset);
+
+        cache.set(cacheKey, { svg, ts: Date.now() });
+        return res.send(svg);
+    } catch (err) {
+        return res.status(500).send(err.message);
+    }
+};
+
+/**
+ * Route descriptor consumed by the auto-registration layer (#52). Public route —
+ * reads the session token when present, falling back to GITHUB_TOKEN.
+ */
+export const route = { method: 'get', path: '/language-trend', auth: false };

--- a/api/social-links.js
+++ b/api/social-links.js
@@ -1,0 +1,125 @@
+import { renderSocialLinks } from '../src/tiles/social-links.js';
+import { readConfig } from '../src/github/config.js';
+import * as simpleIcons from 'simple-icons';
+
+/**
+ * Known social platforms → how to label, find a brand icon, and build a profile
+ * URL from a bare handle. `slug` is the simple-icons export name; a missing or
+ * unknown slug degrades to the renderer's generic link glyph. `url` receives the
+ * raw handle and returns a full URL (handles already-absolute URLs upstream).
+ */
+const PLATFORMS = {
+    github:        { label: 'GitHub',        slug: 'siGithub',        url: h => `https://github.com/${h}` },
+    twitter:       { label: 'X',             slug: 'siX',             url: h => `https://x.com/${h}` },
+    x:             { label: 'X',             slug: 'siX',             url: h => `https://x.com/${h}` },
+    linkedin:      { label: 'LinkedIn',      slug: 'siLinkedin',      url: h => `https://www.linkedin.com/in/${h}` },
+    devto:         { label: 'DEV',           slug: 'siDevdotto',      url: h => `https://dev.to/${h}` },
+    dev:           { label: 'DEV',           slug: 'siDevdotto',      url: h => `https://dev.to/${h}` },
+    mastodon:      { label: 'Mastodon',      slug: 'siMastodon',      url: h => mastodonUrl(h) },
+    youtube:       { label: 'YouTube',       slug: 'siYoutube',       url: h => `https://youtube.com/@${h}` },
+    instagram:     { label: 'Instagram',     slug: 'siInstagram',     url: h => `https://instagram.com/${h}` },
+    twitch:        { label: 'Twitch',        slug: 'siTwitch',        url: h => `https://twitch.tv/${h}` },
+    discord:       { label: 'Discord',       slug: 'siDiscord',       url: h => `https://discord.com/users/${h}` },
+    stackoverflow: { label: 'Stack Overflow', slug: 'siStackoverflow', url: h => `https://stackoverflow.com/users/${h}` },
+    medium:        { label: 'Medium',        slug: 'siMedium',        url: h => `https://medium.com/@${h}` },
+    reddit:        { label: 'Reddit',        slug: 'siReddit',        url: h => `https://reddit.com/user/${h}` },
+    gitlab:        { label: 'GitLab',        slug: 'siGitlab',        url: h => `https://gitlab.com/${h}` },
+    bluesky:       { label: 'Bluesky',       slug: 'siBluesky',       url: h => `https://bsky.app/profile/${h}` },
+    telegram:      { label: 'Telegram',      slug: 'siTelegram',      url: h => `https://t.me/${h}` },
+    facebook:      { label: 'Facebook',      slug: 'siFacebook',      url: h => `https://facebook.com/${h}` },
+    dribbble:      { label: 'Dribbble',      slug: 'siDribbble',      url: h => `https://dribbble.com/${h}` },
+    behance:       { label: 'Behance',       slug: 'siBehance',       url: h => `https://behance.net/${h}` },
+    email:         { label: 'Email',         slug: null,              url: h => `mailto:${h}` },
+    mail:          { label: 'Email',         slug: null,              url: h => `mailto:${h}` },
+    website:       { label: 'Website',       slug: null,              url: h => h },
+    web:           { label: 'Website',       slug: null,              url: h => h },
+    blog:          { label: 'Blog',          slug: null,              url: h => h },
+};
+
+/** Mastodon handles look like `@user@instance.tld`; turn them into a profile URL. */
+const mastodonUrl = (handle) => {
+    const m = handle.replace(/^@/, '').match(/^([^@]+)@(.+)$/);
+    return m ? `https://${m[2]}/@${m[1]}` : `https://mastodon.social/@${handle.replace(/^@/, '')}`;
+};
+
+const isAbsoluteUrl = (s) => /^https?:\/\//i.test(s) || /^mailto:/i.test(s);
+
+/**
+ * Turns one `platform → handle` pair into a renderable badge. Falls back to a
+ * generic link badge (no brand icon) when the platform is unknown.
+ */
+const toBadge = (platformKey, rawHandle) => {
+    const key = String(platformKey).trim().toLowerCase();
+    const handle = String(rawHandle).trim();
+    if (!handle) return null;
+
+    const def = PLATFORMS[key];
+    const icon = def?.slug ? (simpleIcons[def.slug] ?? null) : null;
+    const url = isAbsoluteUrl(handle) ? handle : (def ? def.url(handle) : handle);
+    const label = def?.label ?? key.charAt(0).toUpperCase() + key.slice(1);
+
+    return { key, label, url, icon, hex: icon ? icon.hex : null };
+};
+
+/**
+ * Parses the `?links=` query value: a comma-separated list of `platform:handle`
+ * pairs, e.g. `github:octocat,twitter:foo,email:me@example.com`. The handle may
+ * itself contain colons (full URLs) — only the first colon is treated as the
+ * separator.
+ */
+const parseLinksParam = (value) =>
+    value
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+        .map(pair => {
+            const i = pair.indexOf(':');
+            if (i === -1) return null;
+            return toBadge(pair.slice(0, i), pair.slice(i + 1));
+        })
+        .filter(Boolean);
+
+/** Converts a `.pretty-readme.json` `social` object into badges. */
+const badgesFromConfig = (social) =>
+    Object.entries(social ?? {})
+        .map(([platform, handle]) => toBadge(platform, handle))
+        .filter(Boolean);
+
+/**
+ * GET /social-links
+ *
+ * Renders a row of brand badges linking to the user's social profiles. Links are
+ * sourced (in order) from the `?links=` query param, or the `social` map in the
+ * user's `.pretty-readme.json` when the request is authenticated. Unknown
+ * platforms degrade to a generic link badge.
+ *
+ * Query: ?links=github:octocat,twitter:foo  (overrides config when present)
+ */
+export default async (req, res) => {
+    res.setHeader('Content-Type', 'image/svg+xml');
+
+    try {
+        let badges = [];
+
+        if (req.query.links) {
+            badges = parseLinksParam(req.query.links);
+        } else {
+            const token    = req.session?.github_token ?? process.env.GITHUB_TOKEN;
+            const username = req.session?.github_username ?? req.query.username;
+            if (token && username) {
+                const result = await readConfig(token, username);
+                badges = badgesFromConfig(result?.config?.social);
+            }
+        }
+
+        return res.send(renderSocialLinks(badges));
+    } catch (err) {
+        return res.status(500).send(err.message);
+    }
+};
+
+/**
+ * Route descriptor consumed by the auto-registration layer (#52). Public route —
+ * the handler reads the session when present but does not require auth.
+ */
+export const route = { method: 'get', path: '/social-links', auth: false };

--- a/src/tests/language-trend.test.js
+++ b/src/tests/language-trend.test.js
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'vitest';
+import { renderLanguageTrend } from '../tiles/language-trend.js';
+
+const sample = {
+    buckets: ['2021', '2022', '2023'],
+    series: [
+        { language: 'JavaScript', hex: 'f1e05a', values: [1000, 3000, 5000] },
+        { language: 'Python',     hex: '3572A5', values: [0, 1024, 1024 * 1024] },
+    ],
+};
+
+describe('renderLanguageTrend', () => {
+    test('returns a single well-formed <svg> root', () => {
+        const svg = renderLanguageTrend(sample);
+        expect(svg.trim().startsWith('<svg')).toBe(true);
+        expect(svg.trim().endsWith('</svg>')).toBe(true);
+        expect(svg.match(/<svg\b/g)).toHaveLength(1);
+    });
+
+    test('draws one filled area polygon per series', () => {
+        const svg = renderLanguageTrend(sample);
+        expect(svg.match(/<polygon\b/g)).toHaveLength(2);
+    });
+
+    test('renders a legend entry per language with humanised totals', () => {
+        const svg = renderLanguageTrend(sample);
+        expect(svg).toContain('JavaScript');
+        expect(svg).toContain('Python');
+        expect(svg).toContain('1.0 MB'); // Python final cumulative = 1 MiB
+    });
+
+    test('uses series brand colours', () => {
+        const svg = renderLanguageTrend(sample);
+        expect(svg).toContain('#f1e05a');
+        expect(svg).toContain('#3572A5');
+    });
+
+    test('always labels the chart as an approximation by repo creation date', () => {
+        const svg = renderLanguageTrend(sample);
+        expect(svg.toLowerCase()).toContain('approximate');
+        expect(svg.toLowerCase()).toContain('creation date');
+    });
+
+    test('a custom note overrides the default footnote', () => {
+        const svg = renderLanguageTrend({ ...sample, note: 'Custom footnote' });
+        expect(svg).toContain('Custom footnote');
+    });
+
+    test('falls back to a palette colour when a series has no hex', () => {
+        const svg = renderLanguageTrend({
+            buckets: ['2023'],
+            series: [{ language: 'Brainfuck', values: [42] }],
+        });
+        expect(svg).toMatch(/<polygon\b/);
+        expect(svg).toContain('Brainfuck');
+    });
+
+    test('single bucket still renders a visible band', () => {
+        const svg = renderLanguageTrend({
+            buckets: ['2024'],
+            series: [{ language: 'Go', hex: '00ADD8', values: [2048] }],
+        });
+        expect(svg.match(/<polygon\b/g)).toHaveLength(1);
+        expect(svg).toContain('2.0 KB');
+    });
+
+    test('empty data renders a placeholder, not a broken svg', () => {
+        const svg = renderLanguageTrend({ buckets: [], series: [] });
+        expect(svg.trim().startsWith('<svg')).toBe(true);
+        expect(svg).toContain('No language data');
+    });
+});

--- a/src/tests/social-links.test.js
+++ b/src/tests/social-links.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect } from 'vitest';
+import { siGithub } from 'simple-icons';
+import { renderSocialLinks } from '../tiles/social-links.js';
+
+const githubBadge = {
+    key: 'github',
+    label: 'GitHub',
+    url: 'https://github.com/octocat',
+    icon: siGithub,
+    hex: siGithub.hex,
+};
+
+const unknownBadge = {
+    key: 'carrierpigeon',
+    label: 'Carrierpigeon',
+    url: 'https://example.com/pigeon',
+    icon: null,
+    hex: null,
+};
+
+describe('renderSocialLinks', () => {
+    test('returns a single well-formed <svg> root', () => {
+        const svg = renderSocialLinks([githubBadge]);
+        expect(svg.trim().startsWith('<svg')).toBe(true);
+        expect(svg.trim().endsWith('</svg>')).toBe(true);
+        // exactly one root svg element
+        expect(svg.match(/<svg\b/g)).toHaveLength(1);
+    });
+
+    test('renders a known platform with its brand colour, label and link', () => {
+        const svg = renderSocialLinks([githubBadge]);
+        expect(svg).toContain('GitHub');
+        expect(svg).toContain(`#${siGithub.hex}`);
+        expect(svg).toContain('href="https://github.com/octocat"');
+        expect(svg).toContain(siGithub.path); // brand glyph embedded
+    });
+
+    test('unknown platforms degrade gracefully to a generic link badge', () => {
+        const svg = renderSocialLinks([unknownBadge]);
+        expect(svg).toContain('Carrierpigeon');
+        // neutral styling rather than a brand colour, and no crash
+        expect(svg).toContain('var(--fg60)');
+        expect(svg).toContain('href="https://example.com/pigeon"');
+    });
+
+    test('renders one pill per badge', () => {
+        const svg = renderSocialLinks([githubBadge, unknownBadge]);
+        expect(svg.match(/<rect\b/g)).toHaveLength(2);
+    });
+
+    test('empty input renders a placeholder, not a broken svg', () => {
+        const svg = renderSocialLinks([]);
+        expect(svg.trim().startsWith('<svg')).toBe(true);
+        expect(svg).toContain('No social links');
+    });
+
+    test('escapes XML-significant characters in labels and urls', () => {
+        const svg = renderSocialLinks([{
+            key: 'web', label: 'A & B', url: 'https://x.com/?a=1&b=2', icon: null, hex: null,
+        }]);
+        expect(svg).toContain('A &amp; B');
+        expect(svg).toContain('a=1&amp;b=2');
+        expect(svg).not.toContain('A & B');
+    });
+});

--- a/src/tiles/language-trend.js
+++ b/src/tiles/language-trend.js
@@ -1,0 +1,120 @@
+import { THEME_CSS } from './theme.js';
+
+const W = 820, H = 340;
+const PLOT_X0 = 18;
+const PLOT_X1 = W - 168;     // leave room for the legend
+const PLOT_Y0 = 52;          // below the title
+const PLOT_Y1 = H - 56;      // above the x-axis labels + footnote
+const PLOT_W = PLOT_X1 - PLOT_X0;
+const PLOT_H = PLOT_Y1 - PLOT_Y0;
+
+/** Fallback colours for series whose language has no known brand hex. */
+const PALETTE = ['82aaff', 'c3e88d', 'f78c6c', 'c792ea', 'ffcb6b', '89ddff', 'f07178', 'b2ccd6'];
+
+const escapeXml = (s) =>
+    String(s).replace(/[<>&"']/g, (c) =>
+        ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&apos;' }[c]));
+
+/** Human-readable byte size, e.g. 1536 → "1.5 KB". */
+const fmtBytes = (n) => {
+    if (n < 1024) return `${n} B`;
+    const units = ['KB', 'MB', 'GB'];
+    let v = n / 1024, i = 0;
+    while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+    return `${v >= 100 ? Math.round(v) : v.toFixed(1)} ${units[i]}`;
+};
+
+const colorFor = (series, i) => `#${series.hex ?? PALETTE[i % PALETTE.length]}`;
+
+/**
+ * Renders a cumulative stacked-area chart of language usage over time as an SVG
+ * string. Each series carries its already-cumulative byte total per time bucket;
+ * the chart stacks them so the top edge is the running total across all
+ * languages. The footnote labels the chart as an approximation derived from repo
+ * creation dates, since GitHub exposes no per-commit language history.
+ *
+ * @param {{ buckets:string[], series:Array<{language:string,hex?:(string|null),values:number[]}>, note?:string }} data
+ * @returns {string} a complete theme-aware `<svg>` document.
+ */
+export const renderLanguageTrend = ({ buckets = [], series = [], note } = {}) => {
+    const footnote = note ?? 'Approximate — bucketed by repository creation date';
+
+    if (buckets.length === 0 || series.length === 0) {
+        return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img">
+    ${THEME_CSS}
+    <rect width="${W}" height="${H}" rx="12" style="fill:var(--bg2)"/>
+    <text x="${W / 2}" y="${H / 2}" text-anchor="middle" style="fill:var(--fg40)" font-size="14" font-family="Arial, sans-serif">No language data available</text>
+</svg>`;
+    }
+
+    // X positions for each bucket. A single bucket collapses to a flat band, so
+    // duplicate it to both edges to keep the area visible.
+    const n = buckets.length;
+    const xAt = (i) => n === 1 ? PLOT_X0 + PLOT_W / 2 : PLOT_X0 + (i / (n - 1)) * PLOT_W;
+
+    // Peak total across buckets (cumulative ⇒ usually the last bucket).
+    const totals = buckets.map((_, i) => series.reduce((sum, s) => sum + (s.values[i] ?? 0), 0));
+    const maxTotal = Math.max(...totals, 1);
+    const yAt = (v) => PLOT_Y1 - (v / maxTotal) * PLOT_H;
+
+    // Stack the series, building one filled polygon per language.
+    const baseline = new Array(n).fill(0);
+    const areas = series.map((s, si) => {
+        const color = colorFor(s, si);
+        const topPts = [];
+        const botPts = [];
+        for (let i = 0; i < n; i++) {
+            const x = xAt(i).toFixed(1);
+            const top = baseline[i] + (s.values[i] ?? 0);
+            topPts.push(`${x},${yAt(top).toFixed(1)}`);
+            botPts.push(`${x},${yAt(baseline[i]).toFixed(1)}`);
+            baseline[i] = top;
+        }
+        // For a single bucket, widen the band so the fill is visible.
+        if (n === 1) {
+            const x0 = PLOT_X0.toFixed(1), x1 = PLOT_X1.toFixed(1);
+            const ytop = topPts[0].split(',')[1], ybot = botPts[0].split(',')[1];
+            const poly = `${x0},${ytop} ${x1},${ytop} ${x1},${ybot} ${x0},${ybot}`;
+            return `<polygon points="${poly}" fill="${color}" fill-opacity="0.75"/>`;
+        }
+        const points = [...topPts, ...botPts.reverse()].join(' ');
+        const topLine = topPts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p}`).join(' ');
+        return `<polygon points="${points}" fill="${color}" fill-opacity="0.72"/>
+    <path d="${topLine}" fill="none" stroke="${color}" stroke-width="1.5" stroke-opacity="0.9"/>`;
+    });
+
+    // X-axis bucket labels (skip some when crowded).
+    const labelStep = Math.ceil(n / 8);
+    const xLabels = buckets.map((b, i) => {
+        if (i % labelStep !== 0 && i !== n - 1) return '';
+        return `<text x="${xAt(i).toFixed(1)}" y="${PLOT_Y1 + 18}" text-anchor="middle" style="fill:var(--fg40)" font-size="10" font-family="Arial, sans-serif">${escapeXml(b)}</text>`;
+    }).join('');
+
+    // Legend: swatch + language + final cumulative total.
+    const finals = series.map((s) => s.values[n - 1] ?? 0);
+    const legend = series.map((s, si) => {
+        const ly = PLOT_Y0 + 6 + si * 22;
+        return `<rect x="${PLOT_X1 + 18}" y="${ly}" width="11" height="11" rx="2" fill="${colorFor(s, si)}"/>
+    <text x="${PLOT_X1 + 34}" y="${ly + 10}" style="fill:var(--fg75)" font-size="12" font-family="Arial, sans-serif">${escapeXml(s.language)}</text>
+    <text x="${W - 14}" y="${ly + 10}" text-anchor="end" style="fill:var(--fg40)" font-size="10" font-family="Arial, sans-serif">${fmtBytes(finals[si])}</text>`;
+    }).join('');
+
+    return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img">
+    ${THEME_CSS}
+    <defs>
+        <linearGradient id="lt-bg" x1="0" y1="0" x2="0.4" y2="1">
+            <stop offset="0%" style="stop-color:var(--bg)"/>
+            <stop offset="100%" style="stop-color:var(--bg2)"/>
+        </linearGradient>
+    </defs>
+    <rect width="${W}" height="${H}" fill="url(#lt-bg)" rx="12"/>
+    <text x="${PLOT_X0}" y="30" style="fill:var(--fg)" font-size="16" font-weight="bold" font-family="Arial, sans-serif">Language trend</text>
+    <line x1="${PLOT_X0}" y1="${PLOT_Y1}" x2="${PLOT_X1}" y2="${PLOT_Y1}" style="stroke:var(--fg10)" stroke-width="1"/>
+    ${areas.join('\n    ')}
+    ${xLabels}
+    ${legend}
+    <text x="${PLOT_X0}" y="${H - 14}" style="fill:var(--fg30)" font-size="10" font-style="italic" font-family="Arial, sans-serif">${escapeXml(footnote)}</text>
+</svg>`;
+};
+
+export default renderLanguageTrend;

--- a/src/tiles/social-links.js
+++ b/src/tiles/social-links.js
@@ -1,0 +1,93 @@
+import { THEME_CSS } from './theme.js';
+
+const H = 64;                 // tile height (single row)
+const PILL_H = 40;            // pill height
+const PILL_Y = (H - PILL_H) / 2;
+const PAD_X = 20;             // outer horizontal padding
+const PILL_GAP = 12;          // gap between pills
+const ICON = 18;              // rendered icon size (simple-icons paths are 24×24)
+const ICON_SCALE = ICON / 24;
+const PAD_L = 14;             // pill inner left padding (before icon)
+const PAD_R = 16;             // pill inner right padding (after label)
+const ICON_GAP = 8;          // gap between icon and label
+const LABEL_SIZE = 13;
+const CHAR_W = 7.3;          // approx advance width for one LABEL_SIZE char (Arial)
+
+/**
+ * Generic "link" glyph (24×24) used when a platform has no matching brand icon,
+ * so unknown platforms still render a recognisable badge instead of breaking.
+ */
+const LINK_PATH =
+    'M3.9 12a3.1 3.1 0 0 1 3.1-3.1h4V7h-4a5 5 0 0 0 0 10h4v-1.9h-4A3.1 3.1 0 0 1 3.9 12zm5.1 1h6v-2H9v2zm4-6v1.9h4A3.1 3.1 0 0 1 17 13.1h-4V15h4a5 5 0 0 0 0-10h-4z';
+
+const escapeXml = (s) =>
+    String(s).replace(/[<>&"']/g, (c) =>
+        ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&apos;' }[c]));
+
+const estLabelWidth = (label) => Math.ceil(label.length * CHAR_W);
+
+const pillWidth = (badge) => PAD_L + ICON + ICON_GAP + estLabelWidth(badge.label) + PAD_R;
+
+/**
+ * Renders a single horizontal row of social/links badges as an SVG string.
+ *
+ * Each badge is a brand-tinted pill carrying the platform's simple-icons glyph
+ * and a label. Platforms without a known brand icon fall back to a neutral
+ * "link" glyph so they degrade gracefully rather than disappearing.
+ *
+ * @param {Array<{ key:string, label:string, url?:string, icon?:({path:string,hex:string}|null), hex?:(string|null) }>} badges
+ * @returns {string} a complete `<svg>` document, theme-aware via THEME_CSS.
+ */
+export const renderSocialLinks = (badges) => {
+    const list = Array.isArray(badges) ? badges : [];
+
+    if (list.length === 0) {
+        const W = 280;
+        return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img">
+    ${THEME_CSS}
+    <rect width="${W}" height="${H}" rx="12" style="fill:var(--bg2)"/>
+    <text x="${W / 2}" y="${H / 2 + 4}" text-anchor="middle" style="fill:var(--fg40)" font-size="13" font-family="Arial, sans-serif">No social links configured</text>
+</svg>`;
+    }
+
+    // Lay out pills left-to-right, tracking the running x cursor.
+    let x = PAD_X;
+    const pills = list.map((badge) => {
+        const w = pillWidth(badge);
+        const hex = badge.icon?.hex ?? badge.hex ?? null;
+        const iconColor = hex ? `#${hex}` : null;
+        const iconPath = badge.icon?.path ?? LINK_PATH;
+
+        const iconX = x + PAD_L;
+        const iconY = (H - ICON) / 2;
+        const labelX = iconX + ICON + ICON_GAP;
+
+        // Brand-tinted pill; neutral when no brand colour is known.
+        const fill = iconColor
+            ? `fill="${iconColor}" fill-opacity="0.12"`
+            : `style="fill:var(--fg06)"`;
+        const stroke = iconColor
+            ? `stroke="${iconColor}" stroke-opacity="0.30"`
+            : `style="stroke:var(--fg15)"`;
+        const iconFill = iconColor ? `fill="${iconColor}"` : `style="fill:var(--fg60)"`;
+
+        const pill = `
+    <a${badge.url ? ` href="${escapeXml(badge.url)}" target="_blank" rel="noopener"` : ''}>
+        <rect x="${x}" y="${PILL_Y}" width="${w}" height="${PILL_H}" rx="${PILL_H / 2}" ${fill} ${stroke} stroke-width="1"/>
+        <path d="${iconPath}" transform="translate(${iconX}, ${iconY}) scale(${ICON_SCALE})" ${iconFill}/>
+        <text x="${labelX}" y="${H / 2 + 4}" style="fill:var(--fg)" font-size="${LABEL_SIZE}" font-weight="500" font-family="Arial, sans-serif">${escapeXml(badge.label)}</text>
+    </a>`;
+
+        x += w + PILL_GAP;
+        return pill;
+    });
+
+    const W = x - PILL_GAP + PAD_X; // last gap was added speculatively; trim it
+
+    return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img">
+    ${THEME_CSS}
+    ${pills.join('')}
+</svg>`;
+};
+
+export default renderSocialLinks;


### PR DESCRIPTION
## Summary
Adds the two Phase-2 `account-extra` components as new endpoint handlers + SVG renderers, with unit tests.

- **`/social-links` (#41)** — `src/tiles/social-links.js` + `api/social-links.js`. Renders a row of simple-icons brand badges. Links from `?links=github:octocat,twitter:foo` pairs or the `social` map in the user's `.pretty-readme.json`. Unknown platforms degrade to a generic link badge. Theme-aware.
- **`/language-trend` (#40)** — `src/tiles/language-trend.js` + `api/language-trend.js`. Cumulative stacked-area chart of language bytes bucketed by repo creation year, capped at top-N languages / largest-N repos, cached 15m/user, footnoted as an approximation.

Each handler exports a `{ method, path, auth }` route descriptor and does **not** touch `express.js`.

## ⚠️ Depends on #52 (auto-register routes)
Both issues are blocked by **#52 — auto-register routes**, which is not yet landed. `express.js` still mounts routes manually and there is no descriptor reader, so these routes will **not be live / cannot pass the "auto-mounted" acceptance** until #52 merges. This PR is the interface-first dependent: the modules are inert until #52 reads their descriptors.

**Suggested merge order:** land #52 first, then this. If #52 lands a different descriptor shape than `{ method, path, auth }`, the two `export const route = …` lines are the only adjustment needed (in this stream's files).

## Tests
- `src/tests/social-links.test.js`, `src/tests/language-trend.test.js` — renderer unit tests (15 cases), pass independently of routing.
- Full suite green (34 tests), eslint clean.
- Not yet verifiable end-to-end (route 404s until #52); will add my routes to the smoke test once mounting lands.

Closes #40, #41 (pending #52)

🤖 Generated with [Claude Code](https://claude.com/claude-code)