### PR TITLE
feat: implement GET /repository-readme preview endpoint (#33)

### DIFF
--- a/api/repository-readme.js
+++ b/api/repository-readme.js
@@ -1,18 +1,66 @@
-import { renderReadme } from '../src/markdown/respository';
+import { getRepoSnapshot }           from '../src/github/repo-contents.js';
+import { analyzeRepo }               from '../src/ai/repo-analyzer.js';
+import { scanCache }                 from '../src/scan-cache.js';
+import { generateReadmeFromOutline } from '../src/markdown/repo-readme.js';
 
-export default async (req, res) => {
-    const {
-        username,
-        repository
-    } = req.query;
+/**
+ * GET /repository-readme?repo={name}[&refresh=true]
+ *
+ * Generates a README preview for a single repository: returns the rendered
+ * markdown plus the underlying analysis so the UI can show a preview before the
+ * apply flow pushes it. Requires an authenticated session.
+ *
+ * Reuses the shared scan cache (keyed by user + bare repo name, matching
+ * `/repo-apply`); `?refresh=true` forces a fresh scan. When the analysis has no
+ * README outline, `markdown` is `null` and the analysis is still returned.
+ *
+ * Responses:
+ *   200 { markdown: string|null, analysis }
+ *   400 missing ?repo=
+ *   401 not authenticated
+ *   404 repo not found
+ *   500 unexpected error
+ *
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ */
+const repositoryReadme = async (req, res) => {
+    const token    = req.session?.github_token;
+    const username = req.session?.github_username;
+    if (!token || !username) return res.status(401).json({ error: 'Not authenticated' });
+
+    const repoParam = req.query.repo?.trim();
+    if (!repoParam) return res.status(400).json({ error: 'Missing ?repo= parameter' });
+
+    // Accept either "repo" or "owner/repo"; the scan cache is keyed by bare name.
+    const repo    = repoParam.includes('/') ? repoParam.split('/').pop() : repoParam;
+    const owner   = repoParam.includes('/') ? repoParam.split('/')[0]    : username;
+    const refresh = req.query.refresh === 'true';
 
     try {
-        return res.send(
-            renderReadme()
-        )
+        let analysis = refresh ? null : scanCache.get(username, repo);
+        if (!analysis) {
+            const snapshot = await getRepoSnapshot(token, owner, repo);
+            analysis       = await analyzeRepo(snapshot);
+            scanCache.set(username, repo, analysis);
+        }
+
+        const markdown = generateReadmeFromOutline(repo, analysis);
+        return res.json({ markdown, analysis });
     } catch (err) {
-        return res.send(
-            err.message
-        )
+        console.error(`[repository-readme] ${username}/${repo}:`, err.message);
+        if (/not found/i.test(err.message)) {
+            return res.status(404).json({ error: `Repo not found: ${repo}` });
+        }
+        return res.status(500).json({ error: err.message });
     }
-}
+};
+
+export default repositoryReadme;
+
+/**
+ * Route descriptor for the auto-registration mechanism (#52). Until that lands,
+ * express.js mounts this handler explicitly; the descriptor lets core-http
+ * migrate the mount with no change here.
+ */
+export const route = { method: 'get', path: '/repository-readme', auth: true };

--- a/express.js
+++ b/express.js
@@ -18,6 +18,7 @@ import applyReadme            from './api/apply-readme.js';
 import previewReadme          from './api/preview-readme.js';
 import contributionGraph       from './api/contribution-graph.js';
 import statsCard               from './api/stats-card.js';
+import repositoryReadme       from './api/repository-readme.js';
 import { getConfig, putConfig }                                      from './api/config.js';
 import { authGithub, authCallback, authLogout, authMe, requireAuth } from './api/auth.js';
 import { monkeytypeConnect, monkeytypeDisconnect }                   from './api/monkeytype-connect.js';
@@ -78,6 +79,7 @@ app.get('/repos',                    requireAuth, repos);
 app.get('/repo-apply',               requireAuth, repoApply);
 app.get('/apply-all',                requireAuth, applyAll);
 app.get('/monkeytype',               monkeytype);
+app.get('/repository-readme',        requireAuth, repositoryReadme);
 
 // account-graph stream (#38, #39) — manual append pending #52 auto-registration
 app.get('/contribution-graph',       contributionGraph);


### PR DESCRIPTION
Closes #33. Stacked on #32 (PR #75) — needs `src/markdown/repo-readme.js` to compile; the diff reduces to just the endpoint once #75 merges to develop.

## What
Replaces the `api/repository-readme.js` stub with a working README **preview** endpoint — the read-only sibling of `/repo-apply`, for showing a generated README before applying it.

`GET /repository-readme?repo={name}[&refresh=true]`
- requires an authenticated session
- returns `{ markdown, analysis }` (markdown is `null` when the analysis has no README outline; analysis still returned)
- reuses the shared scan cache (keyed by user + bare repo name, matching `/repo-apply`); `?refresh=true` forces a fresh scan
- accepts either `repo` or `owner/repo`

## Interface-first mounting (per director)
`#52` (route auto-registration, `core-http`) has no active session yet, so per the director I mounted interface-first:
- the handler **exports a `{ method, path, auth }` route descriptor** so core-http can migrate it to auto-registration with no change here
- **append-only** addition to `express.js` (one import + one `app.get` line; no existing routes reordered or touched) so adjacent-line merge conflicts stay trivial

## Acceptance
- [x] `GET /repository-readme?repo={name}` requires auth, returns `{markdown, analysis}`
- [x] reuses scan-cache; `?refresh=true` forces a rescan
- [x] exports a route descriptor; mounted (append-only) pending #52 auto-mount
- [x] 404/400 on missing repo, 401 unauthenticated

## Verification
- `npm run lint` → 0 errors (8 pre-existing warnings; the 2 stub warnings on this file are now gone)
- `npm run test:coverage` → 19/19 pass, exit 0
- Mock req/res checks: unauthenticated → 401, missing `?repo=` → 400, descriptor → `{method:'get',path:'/repository-readme',auth:true}`

Phase 1 · stream `repo-readme` · planner ref J2

🤖 Generated with [Claude Code](https://claude.com/claude-code)