### PR TITLE
test: broaden non-DI test coverage (renderers + pure modules) [#53]

### DIFF
--- a/src/tests/developer-rating.test.js
+++ b/src/tests/developer-rating.test.js
@@ -1,0 +1,149 @@
+import { describe, test, expect } from 'vitest';
+import { computeRating, computeInsights } from '../github/developer-rating.js';
+
+// pushed_at relative to "now" so activity scoring is deterministic per run.
+const daysAgo = (n) => new Date(Date.now() - n * 86400000).toISOString();
+
+const repo = (over = {}) => ({
+    name: 'repo',
+    html_url: 'https://github.com/u/repo',
+    language: 'JavaScript',
+    description: 'A meaningful description well over ten characters',
+    topics: ['react'],
+    size: 200,
+    pushed_at: daysAgo(5),
+    stargazers_count: 10,
+    forks_count: 2,
+    ...over,
+});
+
+const RICH_REPOS = [
+    repo({
+        name: 'a',
+        language: 'JavaScript',
+        topics: ['react', 'aws'],
+        stargazers_count: 100,
+        forks_count: 20,
+    }),
+    repo({
+        name: 'b',
+        language: 'Python',
+        topics: ['django', 'postgresql'],
+        pushed_at: daysAgo(40),
+    }),
+    repo({ name: 'c', language: 'Go', topics: ['docker', 'kubernetes'], pushed_at: daysAgo(200) }),
+    repo({
+        name: 'd',
+        language: 'Rust',
+        topics: ['openai'],
+        description: 'short',
+        size: 10,
+        pushed_at: daysAgo(800),
+    }),
+];
+
+const ALL_DIMENSIONS = ['breadth', 'depth', 'diversity', 'activity', 'impact'];
+
+describe('computeRating', () => {
+    test('returns every base dimension plus overall and tier', () => {
+        const r = computeRating(RICH_REPOS);
+        for (const dim of ALL_DIMENSIONS) {
+            expect(r[dim], dim).toBeTypeOf('number');
+            expect(r[dim]).toBeGreaterThanOrEqual(0);
+            expect(r[dim]).toBeLessThanOrEqual(100);
+        }
+        expect(r.overall).toBeGreaterThanOrEqual(0);
+        expect(r.overall).toBeLessThanOrEqual(100);
+        expect(r.tier).toMatchObject({ label: expect.any(String), color: expect.any(String) });
+    });
+
+    test('tier matches the overall score threshold', () => {
+        const r = computeRating(RICH_REPOS);
+        expect(r.overall).toBeGreaterThanOrEqual(r.tier.min);
+    });
+
+    test('empty repo list scores zero across the board and lands in tier D', () => {
+        const r = computeRating([]);
+        for (const dim of ALL_DIMENSIONS) expect(r[dim]).toBe(0);
+        expect(r.overall).toBe(0);
+        expect(r.tier.label).toBe('D');
+    });
+
+    test('omits engineering and codeQuality when no optional data is supplied', () => {
+        const r = computeRating(RICH_REPOS);
+        expect(r).not.toHaveProperty('engineering');
+        expect(r).not.toHaveProperty('codeQuality');
+    });
+
+    test('includes engineering when workflow metrics are supplied', () => {
+        const metrics = [
+            { hasCi: true, hasDeployments: true, hasClosedIssues: true, hasPrs: true },
+            { hasCi: true, hasDeployments: false, hasClosedIssues: true, hasPrs: false },
+        ];
+        const r = computeRating(RICH_REPOS, metrics);
+        expect(r.engineering).toBeTypeOf('number');
+        expect(r.engineering).toBeGreaterThan(0);
+    });
+
+    test('includes codeQuality averaged from scan data', () => {
+        const scanData = {
+            a: { codeQuality: { overall: 80 } },
+            b: { codeQuality: { overall: 60 } },
+        };
+        const r = computeRating(RICH_REPOS, null, scanData);
+        expect(r.codeQuality).toBe(70); // mean of 80 and 60
+    });
+
+    test('drops codeQuality when scan data has no numeric scores', () => {
+        const r = computeRating(RICH_REPOS, null, { a: { codeQuality: {} } });
+        expect(r).not.toHaveProperty('codeQuality');
+    });
+
+    test('higher stars/forks yield a higher impact score', () => {
+        const low = computeRating([repo({ stargazers_count: 0, forks_count: 0 })]);
+        const high = computeRating([repo({ stargazers_count: 5000, forks_count: 1000 })]);
+        expect(high.impact).toBeGreaterThan(low.impact);
+    });
+
+    test('more recent pushes yield a higher activity score', () => {
+        const stale = computeRating([repo({ pushed_at: daysAgo(900) })]);
+        const fresh = computeRating([repo({ pushed_at: daysAgo(1) })]);
+        expect(fresh.activity).toBeGreaterThan(stale.activity);
+    });
+});
+
+describe('computeInsights', () => {
+    test('returns detail data for every dimension', () => {
+        const insights = computeInsights(RICH_REPOS);
+        expect(insights.breadth.missingCategories).toBeInstanceOf(Array);
+        expect(insights.depth).toBeInstanceOf(Array);
+        expect(insights.diversity).toBeInstanceOf(Array);
+        expect(insights.activity).toBeInstanceOf(Array);
+        expect(insights.impact).toBeInstanceOf(Array);
+        expect(insights.engineering).toBeNull();
+        expect(insights.codeQuality).toBeNull();
+    });
+
+    test('impact details are sorted by weighted popularity, descending', () => {
+        const insights = computeInsights(RICH_REPOS);
+        const weighted = insights.impact.map((e) => e.stars + e.forks * 2);
+        const sorted = [...weighted].sort((a, b) => b - a);
+        expect(weighted).toEqual(sorted);
+    });
+
+    test('breadth details list discovered languages and missing categories', () => {
+        const insights = computeInsights(RICH_REPOS);
+        expect(insights.breadth.languages).toEqual(
+            expect.arrayContaining(['JavaScript', 'Python', 'Go', 'Rust']),
+        );
+        expect(insights.breadth.coveredCategories).toContain('languages');
+    });
+
+    test('engineering details populate when metrics are present', () => {
+        const insights = computeInsights(RICH_REPOS, [
+            { hasCi: true, hasDeployments: false, hasClosedIssues: true, hasPrs: false },
+        ]);
+        expect(insights.engineering.total).toBe(1);
+        expect(insights.engineering.ciCount).toBe(1);
+    });
+});

--- a/src/tests/score-report.test.js
+++ b/src/tests/score-report.test.js
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'vitest';
+import { scoreBadgeMd, generateScoreReport } from '../markdown/score-report.js';
+
+const dim = (score, grade, over = {}) => ({ score, grade, evidence: ['ev'], missing: [], ...over });
+
+const analysis = (over = {}) => ({
+    meta: { owner: 'u', name: 'r', language: 'JavaScript', license: 'MIT' },
+    codeQuality: {
+        overall: 72,
+        grade: 'B',
+        testing: dim(60, 'C', { missing: ['No coverage'] }),
+        documentation: dim(75, 'B'),
+        tooling: dim(80, 'A'),
+        ci: dim(85, 'A'),
+        security: dim(60, 'C'),
+        structure: dim(70, 'B'),
+        ...over.codeQuality,
+    },
+    suggestions: ['Add coverage'],
+    techStack: ['JavaScript', 'Node.js'],
+    ...over,
+});
+
+describe('scoreBadgeMd', () => {
+    test('builds a shields.io badge linking to SCORE.md', () => {
+        const md = scoreBadgeMd(analysis());
+        expect(md).toContain('img.shields.io/badge/code_quality-');
+        expect(md).toContain('72%2F100'); // 72/100, slash encoded
+        expect(md).toContain('](SCORE.md)');
+        expect(md).toContain('-blue?'); // grade B → blue
+    });
+
+    test('encodes the "+" in an A+ grade as %2B', () => {
+        const md = scoreBadgeMd(analysis({ codeQuality: { overall: 95, grade: 'A+' } }));
+        expect(md).toContain('A%2B');
+        expect(md).toContain('-brightgreen?');
+        expect(md).not.toMatch(/badge\/code_quality-A\+/);
+    });
+
+    test('falls back to lightgrey for an unknown grade', () => {
+        const md = scoreBadgeMd(analysis({ codeQuality: { overall: 0, grade: '?' } }));
+        expect(md).toContain('-lightgrey?');
+    });
+});
+
+describe('generateScoreReport edge cases', () => {
+    test('renders an em dash for a missing dimension', () => {
+        const a = analysis();
+        a.codeQuality.security = undefined;
+        const md = generateScoreReport('r', a);
+        expect(md).toContain('| Security | —/100 | — |');
+        // a null dimension contributes no section heading
+        expect(md).not.toContain('## Security —');
+    });
+
+    test('renders notes as a blockquote when present', () => {
+        const a = analysis();
+        a.codeQuality.testing = dim(60, 'C', { notes: 'flaky suite' });
+        const md = generateScoreReport('r', a);
+        expect(md).toContain('> flaky suite');
+    });
+
+    test('draws a progress bar of ten cells for the overall score', () => {
+        const md = generateScoreReport('r', analysis({ codeQuality: { overall: 50, grade: 'B' } }));
+        expect(md).toContain('`█████░░░░░`'); // round(50/10)=5 filled, 5 empty
+    });
+
+    test('omits the suggestions section when there are none', () => {
+        const md = generateScoreReport('r', analysis({ suggestions: [] }));
+        expect(md).not.toContain('## Suggestions');
+    });
+});

--- a/src/tests/tech-data.test.js
+++ b/src/tests/tech-data.test.js
@@ -57,6 +57,22 @@ describe('buildTechSeries', () => {
         const series = buildTechSeries([{}, { topics: [] }], ['languages', 'frameworks'], 10, []);
         expect(series).toHaveLength(0);
     });
+
+    test('ignores topics that are not in the taxonomy', () => {
+        const series = buildTechSeries(
+            [{ topics: ['react', 'some-unknown-topic-xyz'] }],
+            ['frameworks'],
+            10,
+            [],
+        );
+        const frameworks = series.find((s) => s.label === 'Frameworks');
+        expect(frameworks.techs.map((t) => t.name)).toEqual(['React']);
+    });
+
+    test('keeps a language with no known icon, with null icon/hex', () => {
+        const [langs] = buildTechSeries([{ language: 'NotARealLang999' }], ['languages'], 10, []);
+        expect(langs.techs[0]).toMatchObject({ name: 'NotARealLang999', icon: null, hex: null });
+    });
 });
 
 describe('lookupIcon', () => {

--- a/src/tests/tech-data.test.js
+++ b/src/tests/tech-data.test.js
@@ -1,0 +1,73 @@
+import { describe, test, expect } from 'vitest';
+import { buildTechSeries, lookupIcon } from '../github/tech-data.js';
+
+const REPOS = [
+    { language: 'JavaScript', topics: ['react', 'aws'] },
+    { language: 'JavaScript', topics: ['react', 'docker'] },
+    { language: 'Python', topics: ['django', 'postgresql'] },
+    { language: 'Python', topics: ['fastapi'] },
+    { language: 'Go', topics: ['kubernetes'] },
+];
+
+describe('buildTechSeries', () => {
+    test('counts languages and orders them by frequency, descending', () => {
+        const [langs] = buildTechSeries(REPOS, ['languages'], 10, []);
+        expect(langs.label).toBe('Languages');
+        const names = langs.techs.map((t) => t.name);
+        expect(names[0]).toBe('JavaScript'); // 2 repos
+        expect(names).toContain('Python');
+        expect(names).toContain('Go');
+        const jsCount = langs.techs.find((t) => t.name === 'JavaScript').count;
+        expect(jsCount).toBe(2);
+    });
+
+    test('resolves topics through the taxonomy into category series', () => {
+        const series = buildTechSeries(REPOS, ['frameworks', 'cloud'], 10, []);
+        const labels = series.map((s) => s.label);
+        expect(labels).toContain('Frameworks');
+        expect(labels).toContain('Cloud');
+        const frameworks = series.find((s) => s.label === 'Frameworks').techs.map((t) => t.name);
+        expect(frameworks).toContain('React');
+        expect(frameworks).toContain('Django');
+    });
+
+    test('respects the per-category limit', () => {
+        const [langs] = buildTechSeries(REPOS, ['languages'], 1, []);
+        expect(langs.techs).toHaveLength(1);
+        expect(langs.techs[0].name).toBe('JavaScript');
+    });
+
+    test('drops excluded display names (case-insensitive)', () => {
+        const [langs] = buildTechSeries(REPOS, ['languages'], 10, ['javascript']);
+        expect(langs.techs.map((t) => t.name)).not.toContain('JavaScript');
+    });
+
+    test('omits categories that end up empty', () => {
+        const series = buildTechSeries(REPOS, ['ai'], 10, []);
+        expect(series).toHaveLength(0);
+    });
+
+    test('each series carries a label and color from category metadata', () => {
+        const [langs] = buildTechSeries(REPOS, ['languages'], 10, []);
+        expect(langs.color).toMatch(/^#[0-9a-f]{6}$/i);
+        expect(langs.key).toBe('languages');
+    });
+
+    test('handles repos with no topics or language', () => {
+        const series = buildTechSeries([{}, { topics: [] }], ['languages', 'frameworks'], 10, []);
+        expect(series).toHaveLength(0);
+    });
+});
+
+describe('lookupIcon', () => {
+    test('returns an icon object for a well-known technology', () => {
+        const icon = lookupIcon('React');
+        expect(icon).toBeTruthy();
+        expect(icon).toHaveProperty('path');
+        expect(icon).toHaveProperty('hex');
+    });
+
+    test('returns null for an unknown technology', () => {
+        expect(lookupIcon('TotallyNotARealTechName123')).toBeNull();
+    });
+});

--- a/src/tests/tiles.test.js
+++ b/src/tests/tiles.test.js
@@ -251,6 +251,86 @@ describe('renderTechTreemap', () => {
         expect(svg).toContain('LANGUAGES');
         expect(svg).toContain('<rect');
     });
+
+    test('shows icon, clamped name and count for a large tile', () => {
+        const svg = renderTechTreemap([
+            {
+                label: 'L',
+                color: '#123456',
+                techs: [
+                    { name: 'AnExtremelyLongTechName', count: 100, icon: { path: 'M0 0h1v1H0z' } },
+                ],
+            },
+        ]);
+        expectSvgDocument(svg);
+        expect(svg).toContain('M0 0h1v1H0z'); // icon shown on a tall/wide tile
+        expect(svg).toContain('…'); // long name clamped at 14 chars
+    });
+
+    test('suppresses content for tiles that are too small', () => {
+        const many = Array.from({ length: 20 }, (_, i) => ({ name: `tech-${i}`, count: 1 }));
+        const svg = renderTechTreemap([{ label: 'Big', color: '#123456', techs: many }]);
+        expectSvgDocument(svg);
+        // 20 equal tiles in one column are < 32px tall, so no per-tile <text> is emitted
+        expect(svg).not.toContain('>tech-0<');
+    });
+});
+
+// ── renderer edge cases (branch coverage) ───────────────────────────────────────
+
+describe('renderer fallbacks and edge cases', () => {
+    test('spider chart shows a placeholder for fewer than 3 distinct techs', () => {
+        const svg = renderTechSpider([
+            {
+                label: 'X',
+                color: '#ffffff',
+                techs: [
+                    { name: 'A', count: 1 },
+                    { name: 'B', count: 2 },
+                ],
+            },
+        ]);
+        expectSvgDocument(svg);
+        expect(svg).toContain('Not enough data');
+    });
+
+    test('spider chart clamps long names and falls back on missing hex/icon', () => {
+        const svg = renderTechSpider([
+            {
+                label: 'L',
+                color: '#abcabc',
+                techs: [
+                    { name: 'AVeryLongTechnologyName', count: 3 }, // no hex, no icon
+                    { name: 'Two', count: 2 },
+                    { name: 'Three', count: 1 },
+                ],
+            },
+        ]);
+        expect(svg).toContain('…'); // clamped name
+        expect(svg).toContain('#888888'); // hex fallback
+        expect(svg).toContain('<circle'); // icon fallback
+    });
+
+    test('tech-cards falls back to grey when a tech has no hex', () => {
+        const svg = renderTechCards([
+            { label: 'L', color: '#abcdef', techs: [{ name: 'NoHex', count: 1 }] },
+        ]);
+        expectSvgDocument(svg);
+        expect(svg).toContain('#888888');
+    });
+
+    test('tech-grid handles an empty series', () => {
+        const svg = renderTechGrid([]);
+        expectSvgDocument(svg);
+    });
+
+    test('donut chart clamps long language names', () => {
+        const svg = renderDonutChart([
+            { language: 'SuperLongLanguageName', count: 5, hex: 'abcabc' },
+        ]);
+        expectSvgDocument(svg);
+        expect(svg).toContain('…');
+    });
 });
 
 // ── backgrounds ─────────────────────────────────────────────────────────────────

--- a/src/tests/tiles.test.js
+++ b/src/tests/tiles.test.js
@@ -1,0 +1,287 @@
+import { describe, test, expect } from 'vitest';
+
+import { renderAccountSummary } from '../tiles/account-summary.js';
+import { renderTechSummary } from '../tiles/tech-summary.js';
+import { renderDeveloperRating } from '../tiles/developer-rating.js';
+import { renderMonkeytypeChart } from '../tiles/monkeytype-chart.js';
+import { renderTechChart, renderDonutChart, renderSpiderChart } from '../tiles/tech-chart.js';
+import { renderTechCards } from '../tiles/tech-cards.js';
+import { renderTechGrid } from '../tiles/tech-grid.js';
+import { renderTechSpider } from '../tiles/tech-spider.js';
+import { renderTechTreemap } from '../tiles/tech-treemap.js';
+import { renderGeometric } from '../backgrounds/geometric.js';
+import { renderVaporWave } from '../backgrounds/vapor-wave.js';
+import { renderCherryBlossom } from '../backgrounds/cherry-blossom.js';
+import { THEME_CSS } from '../tiles/theme.js';
+
+// ── Shared assertions ────────────────────────────────────────────────────────
+
+/** Every tile renderer must emit a single, reasonably-sized SVG document. */
+const expectSvgDocument = (svg) => {
+    expect(typeof svg).toBe('string');
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('</svg>');
+    // Each <svg opening tag has a matching close.
+    const opens = (svg.match(/<svg[\s>]/g) || []).length;
+    const closes = (svg.match(/<\/svg>/g) || []).length;
+    expect(opens).toBe(closes);
+    expect(svg.length).toBeGreaterThan(50);
+};
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ICONS = [
+    { hex: 'f7df1e', path: 'M0 0h24v24H0z' },
+    { hex: '3776ab', path: 'M1 1h22v22H1z' },
+    { hex: 'e34c26', path: 'M2 2h20v20H2z' },
+];
+
+const LANGS = [
+    { language: 'JavaScript', count: 12, hex: 'f7df1e', icon: { path: 'M0 0h24v24H0z' } },
+    { language: 'Python', count: 8, hex: '3776ab', icon: { path: 'M1 1h22v22H1z' } },
+    { language: 'TypeScript', count: 5, hex: '3178c6' },
+    { language: 'Go', count: 3, hex: '00add8' },
+];
+
+const RATING = {
+    breadth: 70,
+    depth: 65,
+    diversity: 80,
+    activity: 55,
+    impact: 60,
+    overall: 66,
+    tier: { label: 'B', color: '#82aaff' },
+};
+
+const MODES = [
+    { duration: '15', wpm: 110, acc: 97.4, consistency: 80 },
+    { duration: '30', wpm: 105, acc: 96.1, consistency: 78 },
+    { duration: '60', wpm: 98, acc: 95.0, consistency: 75 },
+];
+
+const SERIES = [
+    {
+        label: 'Languages',
+        color: '#82aaff',
+        techs: [
+            { name: 'JavaScript', count: 12, hex: 'f7df1e', icon: { path: 'M0 0h24v24H0z' } },
+            { name: 'Python', count: 8, hex: '3776ab' },
+            { name: 'Go', count: 4, hex: '00add8' },
+        ],
+    },
+    {
+        label: 'Frameworks',
+        color: '#c792ea',
+        techs: [
+            { name: 'Express', count: 6, hex: '000000' },
+            { name: 'React', count: 5, hex: '61dafb' },
+            { name: 'Vue', count: 3, hex: '4fc08d' },
+        ],
+    },
+];
+
+// ── account-summary ────────────────────────────────────────────────────────────
+
+// A summary long enough (>100 chars) that chunkText pushes at least one chunk —
+// see the trailing-chunk note below for why very short summaries render no text.
+const SUMMARY =
+    'passionate developer building open source tools across many languages and frameworks with a focus on clean maintainable code';
+
+describe('renderAccountSummary', () => {
+    test('emits an SVG document containing the summary text and CSS class', () => {
+        const svg = renderAccountSummary(SUMMARY, renderGeometric);
+        expectSvgDocument(svg);
+        expect(svg).toContain('passionate');
+        expect(svg).toContain('account-summary-text');
+    });
+
+    test('renders without a background function', () => {
+        const svg = renderAccountSummary(SUMMARY, undefined);
+        expectSvgDocument(svg);
+        expect(svg).toContain('account-summary-text');
+    });
+
+    test('wraps long summaries into multiple text rows', () => {
+        const long = 'word '.repeat(60).trim();
+        const svg = renderAccountSummary(long, renderGeometric);
+        expectSvgDocument(svg);
+        expect((svg.match(/<text/g) || []).length).toBeGreaterThan(1);
+    });
+});
+
+// ── tech-summary ───────────────────────────────────────────────────────────────
+
+describe('renderTechSummary', () => {
+    test('emits an SVG document with one icon group per technology', () => {
+        const svg = renderTechSummary(ICONS, renderGeometric);
+        expectSvgDocument(svg);
+        for (const icon of ICONS) expect(svg).toContain(icon.path);
+    });
+
+    test('handles an empty icon list', () => {
+        const svg = renderTechSummary([], undefined);
+        expectSvgDocument(svg);
+    });
+});
+
+// ── developer-rating ─────────────────────────────────────────────────────────
+
+describe('renderDeveloperRating', () => {
+    test('renders the overall score and tier label', () => {
+        const svg = renderDeveloperRating(RATING);
+        expectSvgDocument(svg);
+        expect(svg).toContain('66');
+        expect(svg).toContain('>B<');
+        expect(svg).toContain(THEME_CSS);
+    });
+
+    test('renders five base dimension bars by default', () => {
+        const svg = renderDeveloperRating(RATING);
+        for (const label of ['BREADTH', 'DEPTH', 'DIVERSITY', 'ACTIVITY', 'IMPACT']) {
+            expect(svg).toContain(label);
+        }
+        expect(svg).not.toContain('ENGINEERING');
+        expect(svg).not.toContain('CODE QUALITY');
+    });
+
+    test('adds engineering and codeQuality bars when present', () => {
+        const svg = renderDeveloperRating({ ...RATING, engineering: 72, codeQuality: 81 });
+        expect(svg).toContain('ENGINEERING');
+        expect(svg).toContain('CODE QUALITY');
+    });
+});
+
+// ── monkeytype-chart ───────────────────────────────────────────────────────────
+
+describe('renderMonkeytypeChart', () => {
+    test('renders the best wpm and a bar per mode', () => {
+        const svg = renderMonkeytypeChart(MODES);
+        expectSvgDocument(svg);
+        expect(svg).toContain('110'); // best wpm
+        expect(svg).toContain('TYPING SPEED');
+        for (const m of MODES) expect(svg).toContain(`${m.duration}S`);
+    });
+
+    test('renders accuracy with one decimal place', () => {
+        const svg = renderMonkeytypeChart(MODES);
+        expect(svg).toContain('97.4% acc');
+    });
+});
+
+// ── tech-chart (donut / spider) ─────────────────────────────────────────────────
+
+describe('renderTechChart', () => {
+    test('donut chart sums the repo total and renders the heading', () => {
+        const svg = renderDonutChart(LANGS);
+        expectSvgDocument(svg);
+        expect(svg).toContain('TECH STACK');
+        expect(svg).toContain('28'); // total = 12+8+5+3
+        expect(svg).toContain('JavaScript');
+    });
+
+    test('spider chart renders a data polygon for >= 3 languages', () => {
+        const svg = renderSpiderChart(LANGS);
+        expectSvgDocument(svg);
+        expect(svg).toContain('<polygon');
+    });
+
+    test('spider chart falls back to donut for fewer than 3 languages', () => {
+        const svg = renderSpiderChart(LANGS.slice(0, 2));
+        expectSvgDocument(svg);
+        expect(svg).not.toContain('<polygon');
+    });
+
+    test('entry point dispatches on type', () => {
+        expect(renderTechChart(LANGS, 'spider')).toContain('<polygon');
+        expect(renderTechChart(LANGS, 'donut')).not.toContain('<polygon');
+        expect(renderTechChart(LANGS)).toBe(renderDonutChart(LANGS)); // default = donut
+    });
+
+    test('falls back to a circle when a language has no icon', () => {
+        const svg = renderDonutChart([{ language: 'Rust', count: 1, hex: 'dea584' }]);
+        expectSvgDocument(svg);
+        expect(svg).toContain('<circle');
+    });
+});
+
+// ── category tiles (cards / grid / spider / treemap) ─────────────────────────────
+
+describe('renderTechCards', () => {
+    test('renders a card per category (labels upper-cased) with tech names', () => {
+        const svg = renderTechCards(SERIES);
+        expectSvgDocument(svg);
+        expect(svg).toContain('LANGUAGES');
+        expect(svg).toContain('FRAMEWORKS');
+        expect(svg).toContain('Python'); // tech names <= 8 chars render in full
+    });
+});
+
+describe('renderTechGrid', () => {
+    test('renders an SVG containing every category label', () => {
+        const svg = renderTechGrid(SERIES, undefined, { columns: 2 });
+        expectSvgDocument(svg);
+        expect(svg).toContain(THEME_CSS);
+        expect(svg).toContain('Languages');
+        expect(svg).toContain('Frameworks');
+    });
+
+    test('handles a single category', () => {
+        const svg = renderTechGrid([SERIES[0]]);
+        expectSvgDocument(svg);
+    });
+});
+
+describe('renderTechSpider', () => {
+    test('renders a radar SVG with the supplied title', () => {
+        const svg = renderTechSpider(SERIES, 'MY RADAR');
+        expectSvgDocument(svg);
+        expect(svg).toContain('MY RADAR');
+    });
+
+    test('defaults the title when none is given', () => {
+        const svg = renderTechSpider(SERIES);
+        expect(svg).toContain('TECH RADAR');
+    });
+});
+
+describe('renderTechTreemap', () => {
+    test('renders proportional columns with category labels (upper-cased)', () => {
+        const svg = renderTechTreemap(SERIES);
+        expectSvgDocument(svg);
+        expect(svg).toContain('LANGUAGES');
+        expect(svg).toContain('<rect');
+    });
+});
+
+// ── backgrounds ─────────────────────────────────────────────────────────────────
+
+describe('background renderers', () => {
+    test('renderGeometric returns SVG markup sized to the canvas', () => {
+        const bg = renderGeometric(540, 960);
+        expect(typeof bg).toBe('string');
+        expect(bg.length).toBeGreaterThan(0);
+    });
+
+    test('renderVaporWave returns SVG markup', () => {
+        const bg = renderVaporWave(540, 960);
+        expect(typeof bg).toBe('string');
+        expect(bg.length).toBeGreaterThan(0);
+    });
+
+    test('renderCherryBlossom wraps the provided body', () => {
+        const bg = renderCherryBlossom('<g id="probe"/>');
+        expect(bg).toContain('<svg');
+        expect(bg).toContain('id="probe"');
+        expect(bg).toContain('cherry-blossom-leaf-gradient');
+    });
+});
+
+// ── shared theme ─────────────────────────────────────────────────────────────────
+
+describe('THEME_CSS', () => {
+    test('defines dark defaults and a light-mode media override', () => {
+        expect(THEME_CSS).toContain('<style>');
+        expect(THEME_CSS).toContain('--bg:#0d1117');
+        expect(THEME_CSS).toContain('prefers-color-scheme:light');
+    });
+});

--- a/src/tests/util.test.js
+++ b/src/tests/util.test.js
@@ -3,6 +3,7 @@ import { decode } from '../util/base64.js';
 import { previewCache } from '../preview-cache.js';
 import { Tile } from '../common/Tile.js';
 import { TAXONOMY, CATEGORY_META } from '../data/tech-taxonomy.js';
+import LANGUAGE_ICON_MAP from '../icons/languages.js';
 
 describe('base64.decode', () => {
     test('decodes a valid base64 string', () => {
@@ -108,5 +109,24 @@ describe('tech taxonomy data', () => {
 
     test('CATEGORY_META includes a languages entry', () => {
         expect(CATEGORY_META.languages).toMatchObject({ label: 'Languages' });
+    });
+});
+
+describe('language icon map', () => {
+    // Guards against simple-icons renaming/removing a slug, which would silently
+    // make an entry undefined and break icon rendering in tech-data.lookupIcon.
+    test('every entry resolves to a valid simple-icons object', () => {
+        const entries = Object.entries(LANGUAGE_ICON_MAP);
+        expect(entries.length).toBeGreaterThan(0);
+        for (const [language, icon] of entries) {
+            expect(icon, language).toBeTruthy();
+            expect(icon.path, language).toBeTypeOf('string');
+            expect(icon.hex, language).toMatch(/^[0-9a-f]{3,6}$/i);
+        }
+    });
+
+    test('keys are GitHub language names used for lookup', () => {
+        expect(LANGUAGE_ICON_MAP).toHaveProperty('JavaScript');
+        expect(LANGUAGE_ICON_MAP).toHaveProperty('Python');
     });
 });

--- a/src/tests/util.test.js
+++ b/src/tests/util.test.js
@@ -1,0 +1,112 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { decode } from '../util/base64.js';
+import { previewCache } from '../preview-cache.js';
+import { Tile } from '../common/Tile.js';
+import { TAXONOMY, CATEGORY_META } from '../data/tech-taxonomy.js';
+
+describe('base64.decode', () => {
+    test('decodes a valid base64 string', () => {
+        expect(decode('aGVsbG8=')).toBe('hello');
+    });
+
+    test('round-trips with btoa', () => {
+        expect(decode(btoa('github-pretty-readme'))).toBe('github-pretty-readme');
+    });
+
+    test('returns null for invalid input rather than throwing', () => {
+        expect(decode('not valid base64!!!')).toBeNull();
+    });
+});
+
+describe('previewCache', () => {
+    afterEach(() => {
+        previewCache.clear('alice');
+        vi.useRealTimers();
+    });
+
+    test('stores and retrieves a value per username', () => {
+        previewCache.set('alice', { svg: '<svg/>' });
+        expect(previewCache.get('alice')).toEqual({ svg: '<svg/>' });
+    });
+
+    test('returns null for an unknown username', () => {
+        expect(previewCache.get('nobody-here')).toBeNull();
+    });
+
+    test('clear removes a stored value', () => {
+        previewCache.set('alice', 1);
+        previewCache.clear('alice');
+        expect(previewCache.get('alice')).toBeNull();
+    });
+
+    test('expires entries after the 30-minute TTL', () => {
+        vi.useFakeTimers();
+        previewCache.set('alice', 'fresh');
+        expect(previewCache.get('alice')).toBe('fresh');
+        vi.advanceTimersByTime(31 * 60 * 1000);
+        expect(previewCache.get('alice')).toBeNull();
+    });
+});
+
+describe('Tile', () => {
+    // Callers always call setBackground before render (with a function, or a
+    // falsy value for "no background"). Note: the constructor's default
+    // background of {} is truthy-but-not-callable, so render() throws if
+    // setBackground is never called — a latent bug in src/common/Tile.js.
+    test('renders an SVG document with the given dimensions', () => {
+        const tile = new Tile({ height: 300, width: 600 });
+        tile.setBackground(null);
+        const svg = tile.render('<rect/>');
+        expect(svg).toContain('height="300"');
+        expect(svg).toContain('width="600"');
+        expect(svg).toContain('viewBox="0 0 600 300"');
+        expect(svg).toContain('<rect/>');
+        expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+    });
+
+    test('applies CSS set via setCss', () => {
+        const tile = new Tile({});
+        tile.setBackground(null);
+        tile.setCss('.x { fill: red; }');
+        expect(tile.render('')).toContain('.x { fill: red; }');
+    });
+
+    test('invokes the background function with height and width', () => {
+        const tile = new Tile({ height: 100, width: 200 });
+        const bg = vi.fn(() => '<g id="bg"/>');
+        tile.setBackground(bg);
+        const svg = tile.render('');
+        expect(bg).toHaveBeenCalledWith(100, 200);
+        expect(svg).toContain('<g id="bg"/>');
+    });
+
+    test('defaults to 540x960 when no dimensions are given', () => {
+        const tile = new Tile({});
+        tile.setBackground(null);
+        const svg = tile.render('');
+        expect(svg).toContain('height="540"');
+        expect(svg).toContain('width="960"');
+    });
+});
+
+describe('tech taxonomy data', () => {
+    test('every taxonomy entry has a category and display name', () => {
+        for (const [slug, entry] of Object.entries(TAXONOMY)) {
+            expect(entry.category, slug).toBeTypeOf('string');
+            expect(entry.displayName, slug).toBeTypeOf('string');
+        }
+    });
+
+    test('every taxonomy category (besides languages) has metadata', () => {
+        const categories = new Set(Object.values(TAXONOMY).map((e) => e.category));
+        for (const cat of categories) {
+            expect(CATEGORY_META[cat], cat).toBeDefined();
+            expect(CATEGORY_META[cat].label).toBeTypeOf('string');
+            expect(CATEGORY_META[cat].color).toMatch(/^#[0-9a-f]{6}$/i);
+        }
+    });
+
+    test('CATEGORY_META includes a languages entry', () => {
+        expect(CATEGORY_META.languages).toMatchObject({ label: 'Languages' });
+    });
+});


### PR DESCRIPTION
Partial progress on #53 — the renderer + pure-function half of "broaden test coverage". Adds **79 tests** across 5 new files in `src/tests/`, all green (suite at 137), lint clean. Touches `src/tests/*` only, so it merges with zero conflict.

## What's covered
- **Tile renderers** (`tiles.test.js`, 32): account-summary, tech-summary, developer-rating, monkeytype-chart, tech-chart (donut/spider), tech-cards, tech-grid, tech-spider, tech-treemap, backgrounds, `THEME_CSS` — including fallback/edge branches (missing hex/icon, long-name clamping, "not enough data", tiny-tile suppression). `src/tiles` now ~94% branch.
- **developer-rating** (`developer-rating.test.js`, 13): `computeRating`/`computeInsights` — dimensions, tiers, optional engineering/codeQuality weighting, empty-input edges.
- **tech-data** (`tech-data.test.js`, 11): `buildTechSeries` categorization/limit/exclusion/taxonomy-miss + `lookupIcon`.
- **utilities** (`util.test.js`, 16): `base64.decode`, `previewCache` TTL (fake timers), `Tile.render`, tech-taxonomy invariants, language icon map guard.
- **score-report** (`score-report.test.js`, 7): `scoreBadgeMd` shields.io encoding (incl. `A+` → `%2B`) + report edge branches.

## Scope / follow-up
- Keeps **#53 OPEN**. The remaining criterion — `api/*` handler unit tests — lands as a small follow-up PR against #79's injectable AI/GitHub clients (that PR closes #53). No `vi.mock` against the pre-refactor handlers, per direction.

## Bugs surfaced (not fixed here; outside this stream's owned files)
- `Tile`'s constructor defaults `background` to `{}` (truthy, non-callable) → `render()` throws if `setBackground()` is never called.
- (account-summary trailing-chunk drop was addressed separately by #48.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)