### PR TITLE
feat: opt-in account tiles in profile apply/preview (#42, R1/R2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,35 @@ Add `.pretty-readme.json` to your profile repository (`{username}/{username}`):
 
 Only repos in this list will be touched. You can also manage this file through the app UI at `GET /config` / `PUT /config`.
 
+#### Opt-in profile tiles
+
+The same `.pretty-readme.json` can enable extra account tiles in your profile
+README. All tiles are **off by default** — add a `tiles` block and set the ones
+you want to `true`:
+
+```json
+{
+  "repos": ["my-project"],
+  "tiles": {
+    "contributionGraph": true,
+    "statsCard": true
+  }
+}
+```
+
+| Tile id             | Renders |
+| :------------------ | :------ |
+| `contributionGraph` | Contribution heatmap + current/longest streak (`/contribution-graph`). |
+| `statsCard`         | Stars / commits / PRs / issues / followers / contributed-to card (`/stats-card`). |
+| `languageTrend`     | _Coming soon._ |
+| `socialLinks`       | _Coming soon._ |
+
+Each enabled tile is pushed to `assets/` and injected into your README between
+its markers (e.g. `<!-- contribution-start -->` / `<!-- contribution-end -->`)
+during `GET /apply-readme`. The `GET /preview-readme` response includes the
+rendered tiles under `accountTiles`, and `GET /apply-readme?dry_run=true` lists
+the enabled tile ids under `tiles`.
+
 ### 2 — Add the workflow
 
 Create `.github/workflows/pretty-readme.yml` in your profile repository:

--- a/api/apply-readme.js
+++ b/api/apply-readme.js
@@ -5,6 +5,10 @@ import { renderDeveloperRating }            from '../src/tiles/developer-rating.
 import { buildTechSeries, lookupIcon }      from '../src/github/tech-data.js';
 import { renderTechGrid }                   from '../src/tiles/tech-grid.js';
 import { renderMonkeytypeChart }            from '../src/tiles/monkeytype-chart.js';
+import { getContributionCalendar, getUserStats } from '../src/github/graphql.js';
+import { renderContributionGraph }          from '../src/tiles/contribution-graph.js';
+import { renderStatsCard }                  from '../src/tiles/stats-card.js';
+import { readConfig, resolveEnabledTiles }  from '../src/github/config.js';
 import { GoogleGenerativeAI }              from '@google/generative-ai';
 import { previewCache }                    from '../src/preview-cache.js';
 import { scanCache }                      from '../src/scan-cache.js';
@@ -398,6 +402,60 @@ const renderInsights = (rating, insights, repos, recommendations = '') => {
     return parts.join('\n');
 };
 
+// ── Optional account tiles (opt-in via .pretty-readme.json) ─────────────────────
+
+/**
+ * Builders for the opt-in account tiles, keyed by the canonical tile id used in
+ * `.pretty-readme.json`. Each builder fetches its data and returns an SVG
+ * string. Tiles whose components don't exist yet (languageTrend, socialLinks —
+ * #40/#41) are intentionally absent and are skipped gracefully until added.
+ */
+const ACCOUNT_TILE_BUILDERS = {
+    contributionGraph: async (token, username) =>
+        renderContributionGraph(await getContributionCalendar(token, username), undefined, { username }),
+    statsCard: async (token, username) =>
+        renderStatsCard(await getUserStats(token, username)),
+};
+
+/** Asset path + alt text per tile, used when injecting into the profile README. */
+const ACCOUNT_TILE_ASSETS = {
+    contributionGraph: { asset: 'assets/contribution-graph.svg', alt: 'Contribution Graph', marker: 'contribution' },
+    statsCard:         { asset: 'assets/stats-card.svg',         alt: 'GitHub Stats',       marker: 'stats' },
+};
+
+/**
+ * Read the user's `.pretty-readme.json`, resolve the enabled optional tiles, and
+ * render each one whose builder is available. Failures (config read, GraphQL,
+ * render) are logged and skipped so one tile never breaks the whole apply.
+ *
+ * @returns {Promise<Record<string,string>>} Map of enabled tile id → SVG string.
+ */
+export async function buildAccountTiles(token, username, log = () => {}) {
+    let enabled;
+    try {
+        const result = await readConfig(token, username);
+        enabled = resolveEnabledTiles(result?.config);
+    } catch (err) {
+        log(`Config read failed: ${err.message} (no optional tiles)`);
+        return {};
+    }
+
+    const tiles = {};
+    for (const key of enabled) {
+        const build = ACCOUNT_TILE_BUILDERS[key];
+        if (!build) {
+            log(`Tile "${key}" enabled but not yet implemented — skipping`);
+            continue;
+        }
+        try {
+            tiles[key] = await build(token, username);
+        } catch (err) {
+            log(`Tile "${key}" failed: ${err.message} (skipping)`);
+        }
+    }
+    return tiles;
+}
+
 // ── Core profile generator ────────────────────────────────────────────────────
 
 export async function generateProfile(token, username, monkeyOptions = {}, onProgress = null) {
@@ -480,6 +538,11 @@ export async function generateProfile(token, username, monkeyOptions = {}, onPro
         }
     }
 
+    emit(64, 'Rendering account tiles…');
+    log('Rendering opt-in account tiles…');
+    const accountTiles = await buildAccountTiles(token, username, log);
+    if (Object.keys(accountTiles).length) log(`Enabled account tiles: ${Object.keys(accountTiles).join(', ')}`);
+
     emit(68, 'Generating recommendations…');
     log('Generating personalised recommendations…');
     const recommendations = await generateRecommendations(repos, rating, insights);
@@ -488,7 +551,7 @@ export async function generateProfile(token, username, monkeyOptions = {}, onPro
     log('Rendering developer insights…');
     const insightsMd = renderInsights(rating, insights, repos, recommendations);
 
-    return { bio, ratingSvg, techGridSvg, gridCols, gridRows, badges, monkeytypeSvg, insightsMd, steps };
+    return { bio, ratingSvg, techGridSvg, gridCols, gridRows, badges, monkeytypeSvg, accountTiles, insightsMd, steps };
 }
 
 // ── Route handler ─────────────────────────────────────────────────────────────
@@ -540,7 +603,7 @@ export default async (req, res) => {
         if (!cachedProfile) previewCache.set(username, profile);
 
         if (dryRun) {
-            const result = { ok: true, dry_run: true, steps: profile.steps, bio: profile.bio };
+            const result = { ok: true, dry_run: true, steps: profile.steps, bio: profile.bio, tiles: Object.keys(profile.accountTiles ?? {}) };
             if (send) { send({ type: 'done', ...result }); res.end(); } else { res.json(result); }
             return;
         }
@@ -556,6 +619,8 @@ export default async (req, res) => {
         const SECTIONS = [
             { key: 'summary',   start: '<!-- summary-start -->',     end: '<!-- summary-end -->' },
             { key: 'rating',    start: '<!-- rating-start -->',       end: '<!-- rating-end -->' },
+            { key: 'contribution', start: '<!-- contribution-start -->', end: '<!-- contribution-end -->', optional: true, enabled: () => !!profile.accountTiles?.contributionGraph },
+            { key: 'stats',     start: '<!-- stats-start -->',        end: '<!-- stats-end -->',   optional: true, enabled: () => !!profile.accountTiles?.statsCard },
             { key: 'monkeytype',start: '<!-- monkeytype-start -->',   end: '<!-- monkeytype-end -->', optional: true, enabled: () => !!profile.monkeytypeSvg },
             { key: 'charts',    start: '<!-- tech-charts-start -->',   end: '<!-- tech-charts-end -->' },
             { key: 'badges',    start: '<!-- tech-start -->',          end: '<!-- tech-end -->' },
@@ -568,6 +633,17 @@ export default async (req, res) => {
         await pushAsset(token, repo, 'assets/developer-rating.svg', profile.ratingSvg);
         const ratingLink = `\n<a href="https://github.com/${repo}/blob/main/DEVELOPER_INSIGHTS.md"><img src="./assets/developer-rating.svg" width="100%" alt="Developer Rating" /></a>\n`;
         readme = inject(readme, '<!-- rating-start -->', '<!-- rating-end -->', ratingLink);
+
+        // Opt-in account tiles (#42) — push each enabled tile's asset and inject its image.
+        for (const [key, { asset, alt }] of Object.entries(ACCOUNT_TILE_ASSETS)) {
+            const svg = profile.accountTiles?.[key];
+            if (!svg) continue;
+            send?.({ type: 'progress', pct: 85, msg: `Pushing ${alt}…` });
+            await pushAsset(token, repo, asset, svg);
+            const marker = ACCOUNT_TILE_ASSETS[key].marker;
+            const img = `\n<img src="./${asset}" width="100%" alt="${alt}" />\n`;
+            readme = inject(readme, `<!-- ${marker}-start -->`, `<!-- ${marker}-end -->`, img);
+        }
 
         if (profile.monkeytypeSvg) {
             send?.({ type: 'progress', pct: 87, msg: 'Pushing Monkeytype chart…' });

--- a/api/preview-readme.js
+++ b/api/preview-readme.js
@@ -27,6 +27,7 @@ export default async (req, res) => {
                 ratingSvg:     cached.ratingSvg,
                 techGridSvg:   cached.techGridSvg,
                 monkeytypeSvg: cached.monkeytypeSvg,
+                accountTiles:  cached.accountTiles ?? {},
                 insightsMd:    cached.insightsMd,
             });
         }
@@ -46,6 +47,7 @@ export default async (req, res) => {
             ratingSvg:     profile.ratingSvg,
             techGridSvg:   profile.techGridSvg,
             monkeytypeSvg: profile.monkeytypeSvg,
+            accountTiles:  profile.accountTiles ?? {},
             insightsMd:    profile.insightsMd,
         });
     } catch (err) {

--- a/dev.to.md
+++ b/dev.to.md
@@ -157,6 +157,17 @@ Add `.pretty-readme.json` to your profile repository (`{username}/{username}`). 
 
 You can manage this file from the app UI or directly in GitHub. If this file doesn't exist, the cron job will refuse to run — intentional, so a fresh deploy can't accidentally bulk-update everything.
 
+The same file can opt into extra profile tiles (all off by default) via a `tiles` block — for example a contribution heatmap and a GitHub stats card:
+
+```json
+{
+  "repos": ["my-main-project"],
+  "tiles": { "contributionGraph": true, "statsCard": true }
+}
+```
+
+Enabled tiles are rendered as SVGs, pushed to `assets/`, and injected into your profile README between their markers on the next apply.
+
 ### Step 2 — Add the workflow
 
 In your profile repository (`{username}/{username}`), create `.github/workflows/pretty-readme.yml`:

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,9 +53,11 @@ Renders the dashboard HTML page. Requires an active session.
 
 Generates and pushes SVG graphics and markdown content to the user's GitHub profile README repository (`{username}/{username}`). Requires an active session with `repo` scope.
 
+Opt-in account tiles enabled in `.pretty-readme.json` (`tiles.contributionGraph`, `tiles.statsCard`, …) are rendered, pushed to `assets/`, and injected between their README markers. See [README → Opt-in profile tiles](../README.md#opt-in-profile-tiles).
+
 | Parameter  | Default | Description |
 | :--------- | :------ | :---------- |
-| `dry_run`  | `false` | If `true`, runs without writing to GitHub and returns generated content. |
+| `dry_run`  | `false` | If `true`, runs without writing to GitHub and returns generated content. The response's `tiles` array lists the enabled account-tile ids. |
 
 ---
 
@@ -121,6 +123,31 @@ Generates an SVG developer rating card.
 ### GET /developer-rating-insights
 
 Generates a Markdown report with developer rating insights and recommendations.
+
+---
+
+### GET /contribution-graph
+
+Generates an SVG contribution heatmap (a 53×7 calendar) with current-streak,
+longest-streak, and total-contribution figures, sourced from the GitHub GraphQL
+contribution calendar.
+
+| Parameter    | Default | Description |
+| :----------- | :------ | :---------- |
+| `username`   |         | GitHub username (required if not authenticated). |
+| `background` | `null`  | Theme: `cherry-blossom`, `geometric`, or `vapor-wave` (alias: `theme`). |
+
+---
+
+### GET /stats-card
+
+Generates an SVG stats card — total stars, commits, pull requests, issues,
+followers, and repositories contributed to — aggregated from the GitHub GraphQL
+API. Adapts to light/dark mode via `prefers-color-scheme`.
+
+| Parameter  | Default | Description |
+| :--------- | :------ | :---------- |
+| `username` |         | GitHub username (required if not authenticated). |
 
 ---
 

--- a/src/github/config.js
+++ b/src/github/config.js
@@ -6,6 +6,30 @@ const ghHeaders = (token) => ({
 
 const CONFIG_PATH = '.pretty-readme.json';
 
+/**
+ * Optional account tiles that users can opt into via the `tiles` block of
+ * `.pretty-readme.json`, e.g.:
+ *
+ *   { "tiles": { "contributionGraph": true, "statsCard": true } }
+ *
+ * All tiles are OFF by default — a profile with no `tiles` block (or a missing
+ * config file) renders exactly as before. Keys are the canonical tile ids
+ * shared across the preview and apply flows.
+ */
+export const ACCOUNT_TILES = ['contributionGraph', 'statsCard', 'languageTrend', 'socialLinks'];
+
+/**
+ * Resolve which optional account tiles are enabled for a given config object.
+ *
+ * @param {object|null|undefined} config - Parsed `.pretty-readme.json` contents.
+ * @returns {string[]} Enabled tile ids, in canonical {@link ACCOUNT_TILES} order.
+ *   Only `=== true` enables a tile; unknown keys are ignored.
+ */
+export const resolveEnabledTiles = (config) => {
+    const tiles = config?.tiles ?? {};
+    return ACCOUNT_TILES.filter((key) => tiles[key] === true);
+};
+
 /** Reads .pretty-readme.json from the user's profile repo. Returns null if the file doesn't exist. */
 export const readConfig = async (token, username) => {
     const res = await fetch(

--- a/src/tests/build-account-tiles.test.js
+++ b/src/tests/build-account-tiles.test.js
@@ -1,0 +1,68 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Mock the config + GraphQL layers the builder depends on. Paths resolve to the
+// same absolute modules apply-readme.js imports.
+vi.mock('../github/config.js', () => ({
+    readConfig: vi.fn(),
+    resolveEnabledTiles: vi.fn(),
+}));
+vi.mock('../github/graphql.js', () => ({
+    getContributionCalendar: vi.fn(),
+    getUserStats: vi.fn(),
+}));
+
+import { readConfig, resolveEnabledTiles } from '../github/config.js';
+import { getContributionCalendar, getUserStats } from '../github/graphql.js';
+import { buildAccountTiles } from '../../api/apply-readme.js';
+
+const calendar = { totalContributions: 1, weeks: [{ contributionDays: [{ weekday: 0, contributionCount: 1, color: '#39d353' }] }] };
+const stats = { login: 'kev', name: 'Kevin', stars: 1, commits: 1, prs: 0, issues: 0, followers: 0, repos: 1, contributedTo: 0 };
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    readConfig.mockResolvedValue({ config: {}, sha: 'x' });
+});
+
+describe('buildAccountTiles', () => {
+    test('renders only the enabled, implemented tiles', async () => {
+        resolveEnabledTiles.mockReturnValue(['contributionGraph', 'statsCard']);
+        getContributionCalendar.mockResolvedValue(calendar);
+        getUserStats.mockResolvedValue(stats);
+
+        const tiles = await buildAccountTiles('tok', 'kev');
+
+        expect(Object.keys(tiles).sort()).toEqual(['contributionGraph', 'statsCard']);
+        expect(tiles.contributionGraph).toContain('<svg');
+        expect(tiles.statsCard).toContain('<svg');
+    });
+
+    test('returns empty when no tiles are enabled', async () => {
+        resolveEnabledTiles.mockReturnValue([]);
+        const tiles = await buildAccountTiles('tok', 'kev');
+        expect(tiles).toEqual({});
+        expect(getContributionCalendar).not.toHaveBeenCalled();
+    });
+
+    test('skips enabled-but-unimplemented tiles (languageTrend/socialLinks) without error', async () => {
+        resolveEnabledTiles.mockReturnValue(['languageTrend', 'socialLinks', 'statsCard']);
+        getUserStats.mockResolvedValue(stats);
+
+        const tiles = await buildAccountTiles('tok', 'kev');
+        expect(Object.keys(tiles)).toEqual(['statsCard']);
+    });
+
+    test('a failing tile is skipped, not fatal', async () => {
+        resolveEnabledTiles.mockReturnValue(['contributionGraph', 'statsCard']);
+        getContributionCalendar.mockRejectedValue(new Error('graphql down'));
+        getUserStats.mockResolvedValue(stats);
+
+        const tiles = await buildAccountTiles('tok', 'kev');
+        expect(Object.keys(tiles)).toEqual(['statsCard']);
+    });
+
+    test('a failing config read yields no tiles, not an error', async () => {
+        readConfig.mockRejectedValue(new Error('config 500'));
+        const tiles = await buildAccountTiles('tok', 'kev');
+        expect(tiles).toEqual({});
+    });
+});

--- a/src/tests/config-tiles.test.js
+++ b/src/tests/config-tiles.test.js
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'vitest';
+import { ACCOUNT_TILES, resolveEnabledTiles } from '../github/config.js';
+
+describe('resolveEnabledTiles', () => {
+    test('returns nothing for a missing or empty config (opt-in, default off)', () => {
+        expect(resolveEnabledTiles(null)).toEqual([]);
+        expect(resolveEnabledTiles(undefined)).toEqual([]);
+        expect(resolveEnabledTiles({})).toEqual([]);
+        expect(resolveEnabledTiles({ tiles: {} })).toEqual([]);
+    });
+
+    test('enables only tiles explicitly set to true', () => {
+        const config = { tiles: { contributionGraph: true, statsCard: false, languageTrend: true } };
+        expect(resolveEnabledTiles(config)).toEqual(['contributionGraph', 'languageTrend']);
+    });
+
+    test('ignores unknown keys and truthy-but-not-true values', () => {
+        const config = { tiles: { contributionGraph: 'yes', bogus: true, statsCard: 1 } };
+        expect(resolveEnabledTiles(config)).toEqual([]);
+    });
+
+    test('preserves canonical ACCOUNT_TILES ordering regardless of config key order', () => {
+        const config = { tiles: { statsCard: true, contributionGraph: true } };
+        expect(resolveEnabledTiles(config)).toEqual(['contributionGraph', 'statsCard']);
+    });
+
+    test('every advertised tile id is resolvable', () => {
+        const allOn = { tiles: Object.fromEntries(ACCOUNT_TILES.map((k) => [k, true])) };
+        expect(resolveEnabledTiles(allOn)).toEqual(ACCOUNT_TILES);
+    });
+});


### PR DESCRIPTION
## Summary
Integrates the new account tiles into the profile apply/preview flow, gated by `.pretty-readme.json` — **all tiles off by default**, so existing profiles render unchanged.

- `src/github/config.js`: `ACCOUNT_TILES` registry + `resolveEnabledTiles(config)` (only `=== true` enables; canonical ordering).
- `api/apply-readme.js`: `buildAccountTiles()` reads the config, renders each enabled+implemented tile, and is resilient (config/GraphQL/render failures are logged & skipped). `generateProfile` returns `accountTiles`; the apply handler pushes each SVG to `assets/` and injects it between README markers (`contribution`, `stats`). `dry_run` reports enabled tile ids.
- `api/preview-readme.js`: surfaces `accountTiles` in cached + fresh responses.

## Scope
Wires **R1/R2** (`contributionGraph`, `statsCard`) now. **R3/R4** (`languageTrend` #40, `socialLinks` #41, `account-extra` stream) are recognized in config and the README, and slot in via **one registry entry each** (`ACCOUNT_TILE_BUILDERS` + `ACCOUNT_TILE_ASSETS`) once their tile modules land — so #42 closes with a tiny follow-up.

## Testing
- 10 new tests: `resolveEnabledTiles` edge cases; `buildAccountTiles` (enabled / skip-unimplemented / tile-failure / config-failure).
- Full suite **63 passed**, 0 lint errors. Backward-compatible (default off).

## Docs
README opt-in tiles section, `docs/api.md` (`/contribution-graph`, `/stats-card`, apply `dry_run`), `dev.to.md` allowlist note.

Part of #42 — R3/R4 wiring follows #40/#41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)