### PR TITLE
feat: complete #42 — languageTrend + socialLinks tiles in apply/preview (R3/R4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,14 @@ you want to `true`:
   "repos": ["my-project"],
   "tiles": {
     "contributionGraph": true,
-    "statsCard": true
+    "statsCard": true,
+    "languageTrend": true,
+    "socialLinks": true
+  },
+  "social": {
+    "github": "octocat",
+    "linkedin": "octocat",
+    "email": "octocat@github.com"
   }
 }
 ```
@@ -393,8 +400,12 @@ you want to `true`:
 | :------------------ | :------ |
 | `contributionGraph` | Contribution heatmap + current/longest streak (`/contribution-graph`). |
 | `statsCard`         | Stars / commits / PRs / issues / followers / contributed-to card (`/stats-card`). |
-| `languageTrend`     | _Coming soon._ |
-| `socialLinks`       | _Coming soon._ |
+| `languageTrend`     | Cumulative language-usage-over-time stacked area chart (`/language-trend`). |
+| `socialLinks`       | Brand badges linking to your social profiles (`/social-links`), built from the `social` map below. |
+
+The `socialLinks` tile reads the top-level `social` map — `platform: handle`
+pairs (e.g. `github`, `twitter`/`x`, `linkedin`, `devto`, `mastodon`, `email`,
+`website`). Unknown platforms degrade to a generic link badge.
 
 Each enabled tile is pushed to `assets/` and injected into your README between
 its markers (e.g. `<!-- contribution-start -->` / `<!-- contribution-end -->`)

--- a/api/apply-readme.js
+++ b/api/apply-readme.js
@@ -8,6 +8,10 @@ import { renderMonkeytypeChart }            from '../src/tiles/monkeytype-chart.
 import { getContributionCalendar, getUserStats } from '../src/github/graphql.js';
 import { renderContributionGraph }          from '../src/tiles/contribution-graph.js';
 import { renderStatsCard }                  from '../src/tiles/stats-card.js';
+import { renderLanguageTrend }              from '../src/tiles/language-trend.js';
+import { renderSocialLinks }                from '../src/tiles/social-links.js';
+import { buildDataset as buildLanguageTrendDataset } from './language-trend.js';
+import { badgesFromConfig as buildSocialBadges }     from './social-links.js';
 import { readConfig, resolveEnabledTiles }  from '../src/github/config.js';
 import { GoogleGenerativeAI }              from '@google/generative-ai';
 import { previewCache }                    from '../src/preview-cache.js';
@@ -404,23 +408,34 @@ const renderInsights = (rating, insights, repos, recommendations = '') => {
 
 // ── Optional account tiles (opt-in via .pretty-readme.json) ─────────────────────
 
+// Defaults mirror the /language-trend endpoint (REPO_CAP_DEFAULT / LANG_LIMIT_DEFAULT).
+const LANGUAGE_TREND_REPO_CAP = 40;
+const LANGUAGE_TREND_LANG_LIMIT = 6;
+
 /**
  * Builders for the opt-in account tiles, keyed by the canonical tile id used in
- * `.pretty-readme.json`. Each builder fetches its data and returns an SVG
- * string. Tiles whose components don't exist yet (languageTrend, socialLinks —
- * #40/#41) are intentionally absent and are skipped gracefully until added.
+ * `.pretty-readme.json`. Each builder receives a context `{ token, username,
+ * repos, config }` and returns an SVG string. Data builders are reused from the
+ * standalone endpoints (`buildLanguageTrendDataset`, `buildSocialBadges`) rather
+ * than duplicated, so the apply output stays in lock-step with the endpoints.
  */
 const ACCOUNT_TILE_BUILDERS = {
-    contributionGraph: async (token, username) =>
+    contributionGraph: async ({ token, username }) =>
         renderContributionGraph(await getContributionCalendar(token, username), undefined, { username }),
-    statsCard: async (token, username) =>
+    statsCard: async ({ token, username }) =>
         renderStatsCard(await getUserStats(token, username)),
+    languageTrend: async ({ token, repos }) =>
+        renderLanguageTrend(await buildLanguageTrendDataset(repos, token, LANGUAGE_TREND_REPO_CAP, LANGUAGE_TREND_LANG_LIMIT)),
+    socialLinks: async ({ config }) =>
+        renderSocialLinks(buildSocialBadges(config?.social)),
 };
 
 /** Asset path + alt text per tile, used when injecting into the profile README. */
 const ACCOUNT_TILE_ASSETS = {
     contributionGraph: { asset: 'assets/contribution-graph.svg', alt: 'Contribution Graph', marker: 'contribution' },
     statsCard:         { asset: 'assets/stats-card.svg',         alt: 'GitHub Stats',       marker: 'stats' },
+    languageTrend:     { asset: 'assets/language-trend.svg',     alt: 'Language Trend',     marker: 'language-trend' },
+    socialLinks:       { asset: 'assets/social-links.svg',       alt: 'Social Links',       marker: 'social-links' },
 };
 
 /**
@@ -430,16 +445,20 @@ const ACCOUNT_TILE_ASSETS = {
  *
  * @returns {Promise<Record<string,string>>} Map of enabled tile id → SVG string.
  */
-export async function buildAccountTiles(token, username, log = () => {}) {
+export async function buildAccountTiles(ctx, log = () => {}) {
+    const { token, username } = ctx;
+    let config;
     let enabled;
     try {
         const result = await readConfig(token, username);
-        enabled = resolveEnabledTiles(result?.config);
+        config = result?.config;
+        enabled = resolveEnabledTiles(config);
     } catch (err) {
         log(`Config read failed: ${err.message} (no optional tiles)`);
         return {};
     }
 
+    const buildCtx = { ...ctx, config };
     const tiles = {};
     for (const key of enabled) {
         const build = ACCOUNT_TILE_BUILDERS[key];
@@ -448,7 +467,7 @@ export async function buildAccountTiles(token, username, log = () => {}) {
             continue;
         }
         try {
-            tiles[key] = await build(token, username);
+            tiles[key] = await build(buildCtx);
         } catch (err) {
             log(`Tile "${key}" failed: ${err.message} (skipping)`);
         }
@@ -540,7 +559,7 @@ export async function generateProfile(token, username, monkeyOptions = {}, onPro
 
     emit(64, 'Rendering account tiles…');
     log('Rendering opt-in account tiles…');
-    const accountTiles = await buildAccountTiles(token, username, log);
+    const accountTiles = await buildAccountTiles({ token, username, repos }, log);
     if (Object.keys(accountTiles).length) log(`Enabled account tiles: ${Object.keys(accountTiles).join(', ')}`);
 
     emit(68, 'Generating recommendations…');
@@ -621,6 +640,8 @@ export default async (req, res) => {
             { key: 'rating',    start: '<!-- rating-start -->',       end: '<!-- rating-end -->' },
             { key: 'contribution', start: '<!-- contribution-start -->', end: '<!-- contribution-end -->', optional: true, enabled: () => !!profile.accountTiles?.contributionGraph },
             { key: 'stats',     start: '<!-- stats-start -->',        end: '<!-- stats-end -->',   optional: true, enabled: () => !!profile.accountTiles?.statsCard },
+            { key: 'language',  start: '<!-- language-trend-start -->', end: '<!-- language-trend-end -->', optional: true, enabled: () => !!profile.accountTiles?.languageTrend },
+            { key: 'social',    start: '<!-- social-links-start -->', end: '<!-- social-links-end -->', optional: true, enabled: () => !!profile.accountTiles?.socialLinks },
             { key: 'monkeytype',start: '<!-- monkeytype-start -->',   end: '<!-- monkeytype-end -->', optional: true, enabled: () => !!profile.monkeytypeSvg },
             { key: 'charts',    start: '<!-- tech-charts-start -->',   end: '<!-- tech-charts-end -->' },
             { key: 'badges',    start: '<!-- tech-start -->',          end: '<!-- tech-end -->' },

--- a/api/language-trend.js
+++ b/api/language-trend.js
@@ -43,7 +43,7 @@ const fetchLanguages = async (owner, repo, token) => {
  *  3. fill the year range contiguously and prefix-sum into cumulative totals,
  *  4. keep the top `langLimit` languages by total bytes.
  */
-const buildDataset = async (repos, token, repoCap, langLimit) => {
+export const buildDataset = async (repos, token, repoCap, langLimit) => {
     const selected = repos
         .filter(r => !r.fork)
         .sort((a, b) => (b.size ?? 0) - (a.size ?? 0))

--- a/api/social-links.js
+++ b/api/social-links.js
@@ -80,7 +80,7 @@ const parseLinksParam = (value) =>
         .filter(Boolean);
 
 /** Converts a `.pretty-readme.json` `social` object into badges. */
-const badgesFromConfig = (social) =>
+export const badgesFromConfig = (social) =>
     Object.entries(social ?? {})
         .map(([platform, handle]) => toBadge(platform, handle))
         .filter(Boolean);

--- a/src/tests/build-account-tiles.test.js
+++ b/src/tests/build-account-tiles.test.js
@@ -1,7 +1,8 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
-// Mock the config + GraphQL layers the builder depends on. Paths resolve to the
-// same absolute modules apply-readme.js imports.
+// Mock the config + GraphQL layers and the two endpoint data-builders the
+// account-tile builders depend on. Paths resolve to the same absolute modules
+// apply-readme.js imports.
 vi.mock('../github/config.js', () => ({
     readConfig: vi.fn(),
     resolveEnabledTiles: vi.fn(),
@@ -10,13 +11,19 @@ vi.mock('../github/graphql.js', () => ({
     getContributionCalendar: vi.fn(),
     getUserStats: vi.fn(),
 }));
+vi.mock('../../api/language-trend.js', () => ({ buildDataset: vi.fn() }));
+vi.mock('../../api/social-links.js', () => ({ badgesFromConfig: vi.fn() }));
 
 import { readConfig, resolveEnabledTiles } from '../github/config.js';
 import { getContributionCalendar, getUserStats } from '../github/graphql.js';
+import { buildDataset } from '../../api/language-trend.js';
+import { badgesFromConfig } from '../../api/social-links.js';
 import { buildAccountTiles } from '../../api/apply-readme.js';
 
 const calendar = { totalContributions: 1, weeks: [{ contributionDays: [{ weekday: 0, contributionCount: 1, color: '#39d353' }] }] };
 const stats = { login: 'kev', name: 'Kevin', stars: 1, commits: 1, prs: 0, issues: 0, followers: 0, repos: 1, contributedTo: 0 };
+const dataset = { buckets: ['2024'], series: [{ language: 'JavaScript', hex: '#f1e05a', values: [10] }] };
+const ctx = (over = {}) => ({ token: 'tok', username: 'kev', repos: [{ name: 'r' }], ...over });
 
 beforeEach(() => {
     vi.clearAllMocks();
@@ -29,26 +36,35 @@ describe('buildAccountTiles', () => {
         getContributionCalendar.mockResolvedValue(calendar);
         getUserStats.mockResolvedValue(stats);
 
-        const tiles = await buildAccountTiles('tok', 'kev');
+        const tiles = await buildAccountTiles(ctx());
 
         expect(Object.keys(tiles).sort()).toEqual(['contributionGraph', 'statsCard']);
         expect(tiles.contributionGraph).toContain('<svg');
         expect(tiles.statsCard).toContain('<svg');
     });
 
-    test('returns empty when no tiles are enabled', async () => {
-        resolveEnabledTiles.mockReturnValue([]);
-        const tiles = await buildAccountTiles('tok', 'kev');
-        expect(tiles).toEqual({});
-        expect(getContributionCalendar).not.toHaveBeenCalled();
+    test('renders R3/R4 tiles via the reused endpoint data-builders', async () => {
+        resolveEnabledTiles.mockReturnValue(['languageTrend', 'socialLinks']);
+        readConfig.mockResolvedValue({ config: { social: { github: 'kev' } }, sha: 'x' });
+        buildDataset.mockResolvedValue(dataset);
+        badgesFromConfig.mockReturnValue([{ key: 'github', label: 'GitHub', url: 'https://github.com/kev', icon: null, hex: null }]);
+
+        const tiles = await buildAccountTiles(ctx());
+
+        expect(Object.keys(tiles).sort()).toEqual(['languageTrend', 'socialLinks']);
+        expect(tiles.languageTrend).toContain('<svg');
+        expect(tiles.socialLinks).toContain('<svg');
+        // language-trend reuses the endpoint builder with the apply repos + default caps
+        expect(buildDataset).toHaveBeenCalledWith([{ name: 'r' }], 'tok', 40, 6);
+        // social-links reuses badgesFromConfig with the config's `social` map
+        expect(badgesFromConfig).toHaveBeenCalledWith({ github: 'kev' });
     });
 
-    test('skips enabled-but-unimplemented tiles (languageTrend/socialLinks) without error', async () => {
-        resolveEnabledTiles.mockReturnValue(['languageTrend', 'socialLinks', 'statsCard']);
-        getUserStats.mockResolvedValue(stats);
-
-        const tiles = await buildAccountTiles('tok', 'kev');
-        expect(Object.keys(tiles)).toEqual(['statsCard']);
+    test('returns empty when no tiles are enabled', async () => {
+        resolveEnabledTiles.mockReturnValue([]);
+        const tiles = await buildAccountTiles(ctx());
+        expect(tiles).toEqual({});
+        expect(getContributionCalendar).not.toHaveBeenCalled();
     });
 
     test('a failing tile is skipped, not fatal', async () => {
@@ -56,13 +72,13 @@ describe('buildAccountTiles', () => {
         getContributionCalendar.mockRejectedValue(new Error('graphql down'));
         getUserStats.mockResolvedValue(stats);
 
-        const tiles = await buildAccountTiles('tok', 'kev');
+        const tiles = await buildAccountTiles(ctx());
         expect(Object.keys(tiles)).toEqual(['statsCard']);
     });
 
     test('a failing config read yields no tiles, not an error', async () => {
         readConfig.mockRejectedValue(new Error('config 500'));
-        const tiles = await buildAccountTiles('tok', 'kev');
+        const tiles = await buildAccountTiles(ctx());
         expect(tiles).toEqual({});
     });
 });


### PR DESCRIPTION
## Summary
Completes **#42**: all R1–R4 account tiles are now selectable, opt-in via `.pretty-readme.json`, in the profile apply/preview flow. Builds on the R1/R2 integration merged in #88.

- **Export-only edits** to `api/language-trend.js` and `api/social-links.js`: added `export` to the existing `buildDataset()` / `badgesFromConfig()` — **no behavior or signature change** (director-authorized, interface-first). The two `bsc-note`d additive touches let apply reuse the endpoints' exact data logic rather than duplicate it (no drift).
- `api/apply-readme.js`: tile builders now receive a `{ token, username, repos, config }` context. `languageTrend` reuses `buildDataset` (apply's already-fetched repos + the endpoint's default caps); `socialLinks` reuses `badgesFromConfig(config.social)`. New `language-trend` / `social-links` README markers + asset pushes flow through the existing generic inject loop.
- `README.md`: documents the two tiles and the `social` config map.

## Testing
- `build-account-tiles` now covers R3/R4, asserting `buildDataset` and `badgesFromConfig` are invoked with the correct inputs (`repos, token, 40, 6` and `config.social`).
- Full suite **229 passed**, 0 lint errors. Backward-compatible (all tiles default off).

## Notes
- Interface-first: the export-only edits to the two `account-extra` files may produce a trivial merge the director resolves.
- #38/#39 were confirmed already delivered in #74 and closed by the director.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)