### PR TITLE
feat: enrich README generator (badges, ToC, config, contributing) + tests (#35, #36)

### DIFF
--- a/src/ai/repo-analyzer.js
+++ b/src/ai/repo-analyzer.js
@@ -297,7 +297,11 @@ Return a JSON object with EXACTLY this structure:
     "tagline": "Single compelling sentence describing what the project does",
     "features": ["Key feature 1", "Key feature 2", "Key feature 3"],
     "installationSteps": ["Step 1", "Step 2"],
-    "usageExample": "A short code or command example showing basic usage"
+    "usageExample": "A short code or command example showing basic usage",
+    "configuration": [
+      { "name": "ENV_VAR_OR_OPTION", "description": "what it controls" }
+    ],
+    "contributing": "1-2 sentences on how to contribute (where to file issues, the PR flow, any dev setup)"
   }
 }
 
@@ -305,7 +309,9 @@ Rules:
 - suggestedTopics must be valid GitHub topic slugs (lowercase, hyphens only, max 35 chars)
 - suggestions must be specific to THIS repo's actual gaps — do not repeat what is already in "already flagged as missing" verbatim, but DO address those gaps with actionable steps
 - codeQualityNotes must reflect what you actually see in the source files and config, not generic advice
-- readmeOutline should be based on the actual purpose and features visible in the code`;
+- readmeOutline should be based on the actual purpose and features visible in the code
+- configuration: list real environment variables or config options found in the code (from .env samples, config files, or documented settings); use an empty array if there are none — do NOT invent them
+- contributing: include only when the repo shows a contribution process (CONTRIBUTING.md, issue templates, an established PR flow); otherwise use an empty string`;
 
     try {
         const result = await model.generateContent(prompt);

--- a/src/markdown/repo-readme.js
+++ b/src/markdown/repo-readme.js
@@ -20,7 +20,22 @@ export const scoreBadgeMd = (analysis) => {
 };
 
 /**
+ * Slugifies a heading into a GitHub-style anchor for table-of-contents links
+ * (lowercase, punctuation stripped, spaces → hyphens). e.g. "Built With" → "built-with".
+ *
+ * @param {string} heading
+ * @returns {string}
+ */
+const anchorFor = (heading) =>
+    heading.toLowerCase().replace(/[^\w\s-]/g, '').trim().replace(/\s+/g, '-');
+
+/**
  * Generates a README.md from a scan's readmeOutline.
+ *
+ * Sections are assembled only when their backing data is present, so a minimal
+ * repo never emits a bare header. A badge row (language, license) is rendered
+ * under the tagline, and a table of contents is included whenever more than one
+ * navigable section exists.
  *
  * @param {string} repoName
  * @param {object} analysis  Result of analyzeRepo()
@@ -30,49 +45,67 @@ export const generateReadmeFromOutline = (repoName, analysis) => {
     const { readmeOutline, techStack, meta } = analysis;
     if (!readmeOutline) return null;
 
-    const { title, tagline, features, installationSteps, usageExample } = readmeOutline;
-    const parts = [];
+    const { title, tagline, features, installationSteps, usageExample, configuration, contributing } = readmeOutline;
 
-    parts.push(`# ${title || repoName}`, '');
-    if (tagline) parts.push(`> ${tagline}`, '');
-
+    // ── Badge row (rendered inline, side by side) ──────────────────────────────
+    const badges = [];
     if (meta?.language) {
-        parts.push(`![${meta.language}](https://img.shields.io/badge/-${encodeURIComponent(meta.language)}-555?style=flat)`);
+        badges.push(`![${meta.language}](https://img.shields.io/badge/-${encodeURIComponent(meta.language)}-555?style=flat)`);
     }
     if (meta?.license) {
-        parts.push(`![License](https://img.shields.io/badge/license-${encodeURIComponent(meta.license)}-blue?style=flat)`);
+        badges.push(`![License](https://img.shields.io/badge/license-${encodeURIComponent(meta.license)}-blue?style=flat)`);
     }
-    if (meta?.language || meta?.license) parts.push('');
+
+    // ── Body sections, in render order; each present one also seeds the ToC ─────
+    const sections = [];
 
     if (features?.length) {
-        parts.push('## Features', '');
-        features.forEach(f => parts.push(`- ${f}`));
+        sections.push({ heading: 'Features', lines: features.map(f => `- ${f}`) });
+    }
+    if (installationSteps?.length) {
+        sections.push({ heading: 'Installation', lines: ['```bash', ...installationSteps, '```'] });
+    }
+    if (usageExample) {
+        sections.push({ heading: 'Usage', lines: ['```', usageExample, '```'] });
+    }
+    if (configuration?.length) {
+        sections.push({
+            heading: 'Configuration',
+            lines: [
+                '| Name | Description |',
+                '| --- | --- |',
+                ...configuration.map(c => `| \`${c.name}\` | ${c.description ?? ''} |`),
+            ],
+        });
+    }
+    if (techStack?.length) {
+        sections.push({ heading: 'Built With', lines: techStack.map(t => `- ${t}`) });
+    }
+    if (contributing) {
+        sections.push({ heading: 'Contributing', lines: [contributing] });
+    }
+    if (meta?.license) {
+        sections.push({ heading: 'License', lines: [`[${meta.license}](LICENSE)`] });
+    }
+
+    // ── Assemble ────────────────────────────────────────────────────────────────
+    const parts = [];
+    parts.push(`# ${title || repoName}`, '');
+    if (tagline) parts.push(`> ${tagline}`, '');
+    if (badges.length) parts.push(badges.join(' '), '');
+
+    // A one-item ToC is noise; only render it when there's something to navigate.
+    if (sections.length > 1) {
+        parts.push('## Table of Contents', '');
+        sections.forEach(s => parts.push(`- [${s.heading}](#${anchorFor(s.heading)})`));
         parts.push('');
     }
 
-    if (installationSteps?.length) {
-        parts.push('## Installation', '');
-        parts.push('```bash');
-        installationSteps.forEach(s => parts.push(s));
-        parts.push('```', '');
-    }
-
-    if (usageExample) {
-        parts.push('## Usage', '');
-        parts.push('```');
-        parts.push(usageExample);
-        parts.push('```', '');
-    }
-
-    if (techStack?.length) {
-        parts.push('## Built With', '');
-        parts.push(techStack.map(t => `- ${t}`).join('\n'), '');
-    }
-
-    if (meta?.license) {
-        parts.push('## License', '');
-        parts.push(`[${meta.license}](LICENSE)`, '');
-    }
+    sections.forEach(s => {
+        parts.push(`## ${s.heading}`, '');
+        s.lines.forEach(l => parts.push(l));
+        parts.push('');
+    });
 
     return parts.join('\n');
 };

--- a/src/tests/repo-readme.test.js
+++ b/src/tests/repo-readme.test.js
@@ -1,0 +1,271 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { generateReadmeFromOutline } from '../markdown/repo-readme.js';
+
+// Mock the network + AI layers so the endpoint test exercises the handler's own
+// logic (auth gating, param parsing, cache use, response shape) against the REAL
+// generator — no live GitHub or Gemini access.
+vi.mock('../github/repo-contents.js', () => ({ getRepoSnapshot: vi.fn() }));
+vi.mock('../ai/repo-analyzer.js', () => ({ analyzeRepo: vi.fn() }));
+vi.mock('../scan-cache.js', () => ({ scanCache: { get: vi.fn(), set: vi.fn() } }));
+
+const { getRepoSnapshot } = await import('../github/repo-contents.js');
+const { analyzeRepo } = await import('../ai/repo-analyzer.js');
+const { scanCache } = await import('../scan-cache.js');
+const repositoryReadme = (await import('../../api/repository-readme.js')).default;
+
+/** Minimal Express-style response double recording status and body. */
+const makeRes = () => {
+    const res = { statusCode: 200, body: undefined };
+    res.status = (c) => {
+        res.statusCode = c;
+        return res;
+    };
+    res.json = (b) => {
+        res.body = b;
+        return res;
+    };
+    return res;
+};
+
+const call = (query = {}, session = {}) => {
+    const res = makeRes();
+    return repositoryReadme({ query, session }, res).then(() => res);
+};
+
+const SESSION = { github_token: 'tok', github_username: 'u' };
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const fullOutline = {
+    title: 'My Project',
+    tagline: 'Does the thing well.',
+    features: ['Fast', 'Tested'],
+    installationSteps: ['npm install', 'npm start'],
+    usageExample: 'import { thing } from "my-project";',
+    configuration: [
+        { name: 'API_KEY', description: 'auth token' },
+        { name: 'PORT', description: 'listen port' },
+    ],
+    contributing: 'Open an issue, then send a PR against develop.',
+};
+
+// Each override fully replaces its field (so a test can pass an empty techStack
+// or a license-less meta); readmeOutline merges onto the full fixture unless an
+// explicit null is given.
+const analysis = (over = {}) => ({
+    meta: over.meta ?? { owner: 'u', name: 'my-project', language: 'JavaScript', license: 'MIT' },
+    techStack: over.techStack ?? ['Node.js', 'Express'],
+    readmeOutline:
+        over.readmeOutline === undefined
+            ? { ...fullOutline }
+            : over.readmeOutline === null
+              ? null
+              : { ...fullOutline, ...over.readmeOutline },
+});
+
+// ── generateReadmeFromOutline: section presence/absence ──────────────────────
+
+describe('generateReadmeFromOutline — sections render when data present', () => {
+    test('renders title, tagline and a badge row', () => {
+        const md = generateReadmeFromOutline('my-project', analysis());
+        expect(md).toMatch(/^# My Project/);
+        expect(md).toContain('> Does the thing well.');
+        // language + license badges share one line (a row), not stacked
+        expect(md).toMatch(/!\[JavaScript\]\([^)]+\) !\[License\]\([^)]+\)/);
+        expect(md).toContain('shields.io/badge/license-MIT-blue');
+    });
+
+    test('falls back to repoName when the outline has no title', () => {
+        const md = generateReadmeFromOutline('fallback-repo', analysis({ readmeOutline: { title: '' } }));
+        expect(md).toMatch(/^# fallback-repo/);
+    });
+
+    test('renders a table of contents linking each section', () => {
+        const md = generateReadmeFromOutline('my-project', analysis());
+        expect(md).toContain('## Table of Contents');
+        expect(md).toContain('- [Features](#features)');
+        expect(md).toContain('- [Installation](#installation)');
+        expect(md).toContain('- [Configuration](#configuration)');
+        expect(md).toContain('- [Built With](#built-with)');
+        expect(md).toContain('- [Contributing](#contributing)');
+        expect(md).toContain('- [License](#license)');
+    });
+
+    test('renders the features list', () => {
+        const md = generateReadmeFromOutline('my-project', analysis());
+        expect(md).toContain('## Features');
+        expect(md).toContain('- Fast');
+        expect(md).toContain('- Tested');
+    });
+
+    test('renders installation steps inside a bash fence', () => {
+        const md = generateReadmeFromOutline('my-project', analysis());
+        expect(md).toContain('## Installation');
+        expect(md).toContain('```bash\nnpm install\nnpm start\n```');
+    });
+
+    test('renders the usage example inside a code fence', () => {
+        const md = generateReadmeFromOutline('my-project', analysis());
+        expect(md).toContain('## Usage');
+        expect(md).toContain('```\nimport { thing } from "my-project";\n```');
+    });
+
+    test('renders configuration as a table', () => {
+        const md = generateReadmeFromOutline('my-project', analysis());
+        expect(md).toContain('## Configuration');
+        expect(md).toContain('| Name | Description |');
+        expect(md).toContain('| `API_KEY` | auth token |');
+        expect(md).toContain('| `PORT` | listen port |');
+    });
+
+    test('renders the tech stack under Built With', () => {
+        const md = generateReadmeFromOutline('my-project', analysis());
+        expect(md).toContain('## Built With');
+        expect(md).toContain('- Node.js');
+        expect(md).toContain('- Express');
+    });
+
+    test('renders the contributing section', () => {
+        const md = generateReadmeFromOutline('my-project', analysis());
+        expect(md).toContain('## Contributing');
+        expect(md).toContain('Open an issue, then send a PR against develop.');
+    });
+
+    test('renders the license section linking LICENSE', () => {
+        const md = generateReadmeFromOutline('my-project', analysis());
+        expect(md).toContain('## License');
+        expect(md).toContain('[MIT](LICENSE)');
+    });
+});
+
+describe('generateReadmeFromOutline — empty sections are omitted', () => {
+    test('returns null when there is no outline', () => {
+        expect(generateReadmeFromOutline('r', { meta: {}, techStack: [], readmeOutline: null })).toBeNull();
+    });
+
+    test('omits every optional section for a minimal outline (no bare headers, no ToC)', () => {
+        const md = generateReadmeFromOutline(
+            'minimal',
+            { meta: {}, techStack: [], readmeOutline: { title: 'Minimal', tagline: '' } },
+        );
+        expect(md).toBe('# Minimal\n');
+        expect(md).not.toContain('## ');
+        expect(md).not.toContain('Table of Contents');
+    });
+
+    test.each([
+        ['Features', { features: [] }],
+        ['Installation', { installationSteps: [] }],
+        ['Usage', { usageExample: '' }],
+        ['Configuration', { configuration: [] }],
+        ['Contributing', { contributing: '' }],
+    ])('omits the %s header when its data is empty', (heading, outlineOver) => {
+        const md = generateReadmeFromOutline(
+            'my-project',
+            analysis({ readmeOutline: outlineOver, techStack: [], meta: { name: 'my-project' } }),
+        );
+        expect(md).not.toContain(`## ${heading}`);
+        expect(md).not.toContain(`#${heading.toLowerCase().replace(/\s+/g, '-')})`);
+    });
+
+    test('omits Built With when techStack is empty and License when no license', () => {
+        const md = generateReadmeFromOutline(
+            'my-project',
+            analysis({ techStack: [], meta: { name: 'my-project', language: 'JavaScript' } }),
+        );
+        expect(md).not.toContain('## Built With');
+        expect(md).not.toContain('## License');
+        // a license badge should not appear without a license
+        expect(md).not.toContain('shields.io/badge/license');
+    });
+
+    test('skips the ToC when only a single section is present', () => {
+        const md = generateReadmeFromOutline(
+            'my-project',
+            { meta: {}, techStack: [], readmeOutline: { title: 'Solo', features: ['only one'] } },
+        );
+        expect(md).toContain('## Features');
+        expect(md).not.toContain('## Table of Contents');
+    });
+});
+
+// ── GET /repository-readme endpoint ──────────────────────────────────────────
+
+describe('GET /repository-readme', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        scanCache.get.mockReturnValue(undefined);
+    });
+
+    test('401 when the session is not authenticated', async () => {
+        const res = await call({ repo: 'my-project' }, {});
+        expect(res.statusCode).toBe(401);
+        expect(getRepoSnapshot).not.toHaveBeenCalled();
+    });
+
+    test('400 when ?repo= is missing', async () => {
+        const res = await call({}, SESSION);
+        expect(res.statusCode).toBe(400);
+    });
+
+    test('scans + analyzes and returns the rendered markdown and analysis', async () => {
+        getRepoSnapshot.mockResolvedValue({ meta: { name: 'my-project' } });
+        analyzeRepo.mockResolvedValue(analysis());
+
+        const res = await call({ repo: 'my-project' }, SESSION);
+
+        expect(res.statusCode).toBe(200);
+        expect(getRepoSnapshot).toHaveBeenCalledWith('tok', 'u', 'my-project');
+        expect(res.body.analysis).toMatchObject({ meta: { name: 'my-project' } });
+        expect(res.body.markdown).toMatch(/^# My Project/);
+        expect(res.body.markdown).toContain('## Table of Contents');
+        expect(res.body.markdown).toContain('## Configuration');
+        // freshly computed analysis is cached for reuse
+        expect(scanCache.set).toHaveBeenCalledWith('u', 'my-project', expect.any(Object));
+    });
+
+    test('splits owner/repo and serves a cached analysis without re-scanning', async () => {
+        scanCache.get.mockReturnValue(analysis());
+
+        const res = await call({ repo: 'someone/my-project' }, SESSION);
+
+        expect(res.statusCode).toBe(200);
+        expect(scanCache.get).toHaveBeenCalledWith('u', 'my-project');
+        expect(getRepoSnapshot).not.toHaveBeenCalled();
+        expect(res.body.markdown).toMatch(/^# My Project/);
+    });
+
+    test('refresh=true bypasses the cache and forces a fresh scan', async () => {
+        scanCache.get.mockReturnValue(analysis());
+        getRepoSnapshot.mockResolvedValue({ meta: { name: 'my-project' } });
+        analyzeRepo.mockResolvedValue(analysis());
+
+        const res = await call({ repo: 'my-project', refresh: 'true' }, SESSION);
+
+        expect(res.statusCode).toBe(200);
+        expect(scanCache.get).not.toHaveBeenCalled();
+        expect(getRepoSnapshot).toHaveBeenCalled();
+    });
+
+    test('returns markdown:null when the analysis has no outline', async () => {
+        getRepoSnapshot.mockResolvedValue({ meta: { name: 'my-project' } });
+        analyzeRepo.mockResolvedValue(analysis({ readmeOutline: null }));
+
+        const res = await call({ repo: 'my-project' }, SESSION);
+        expect(res.statusCode).toBe(200);
+        expect(res.body.markdown).toBeNull();
+        expect(res.body.analysis).toBeDefined();
+    });
+
+    test('404 when the scan reports the repo is not found', async () => {
+        getRepoSnapshot.mockRejectedValue(new Error('Repo not found'));
+        const res = await call({ repo: 'ghost' }, SESSION);
+        expect(res.statusCode).toBe(404);
+    });
+
+    test('500 on an unexpected scan error', async () => {
+        getRepoSnapshot.mockRejectedValue(new Error('boom'));
+        const res = await call({ repo: 'my-project' }, SESSION);
+        expect(res.statusCode).toBe(500);
+    });
+});


### PR DESCRIPTION
Enriches the per-repository README generator and adds its test coverage. Closes #35 and #36 — the two are landed together because the tests directly exercise the new generator code, keeping CI meaningful and avoiding the stacked-PR merge fragility a previous attempt hit.

## #35 — Enrich README outline + generator
- `src/ai/repo-analyzer.js`: extend the `readmeOutline` schema with `configuration` (`[{name, description}]`) and `contributing` fields, with prompt rules to only populate them from real evidence (empty array / empty string otherwise).
- `src/markdown/repo-readme.js`: render a **badge row** (language + license, side by side), a **Table of Contents**, and **Configuration** (as a table) + **Contributing** sections.
- Empty sections are omitted (no bare headers); the ToC is skipped when there's ≤1 navigable section, so minimal repos still render a valid README.

## #36 — Tests
- `src/tests/repo-readme.test.js`: unit tests for each section rendering-when-present / omitted-when-absent (incl. minimal-repo and ToC-skip cases), plus an endpoint suite mocking the scan/analyze layers covering auth gating, `owner/repo` splitting, cache reuse, `refresh=true`, no-outline, and 404/500 error paths.

## Verification
- `npm test` — 280 passed (27 new)
- `npm run lint` — 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)