### PR TITLE
feat: top-repos showcase tile endpoint (closes #66)

### DIFF
--- a/api/top-repos.js
+++ b/api/top-repos.js
@@ -1,0 +1,92 @@
+import { renderTopRepos } from '../src/tiles/top-repos.js';
+import { toCardData } from './repo-card.js';
+import { getRepos, createGithubClient } from '../src/github/repos.js';
+
+const DEFAULT_LIMIT = 6;
+const MAX_LIMIT = 12;
+
+/** Parses a positive integer query value, clamped to [1, max], with a default. */
+const parseLimit = (value, fallback = DEFAULT_LIMIT, max = MAX_LIMIT) => {
+    const n = Math.trunc(Number(value));
+    if (!Number.isFinite(n) || n < 1) return fallback;
+    return Math.min(n, max);
+};
+
+/** Truthy query flag — `?forks=true`/`1` opt in; anything else stays false. */
+const isTrue = (value) => value === 'true' || value === '1';
+
+/**
+ * Orders repos by the requested sort key, returning a new array.
+ * @param {Array} repos  REST repo objects
+ * @param {string} sort  'stars' (default) or 'updated' (most recently pushed)
+ */
+export const sortRepos = (repos, sort) => {
+    const byStars = (a, b) => (b.stargazers_count ?? 0) - (a.stargazers_count ?? 0);
+    const byUpdated = (a, b) =>
+        new Date(b.pushed_at ?? b.updated_at ?? 0).getTime() -
+        new Date(a.pushed_at ?? a.updated_at ?? 0).getTime();
+    return [...repos].sort(sort === 'updated' ? byUpdated : byStars);
+};
+
+/**
+ * Selects the repos to showcase: forks excluded unless opted in, ordered by the
+ * sort key, then truncated to `limit`.
+ * @param {Array} repos
+ * @param {object} opts
+ * @param {string} [opts.sort]         'stars' | 'updated'
+ * @param {number} [opts.limit]
+ * @param {boolean} [opts.includeForks]
+ */
+export const selectRepos = (repos, { sort, limit = DEFAULT_LIMIT, includeForks = false } = {}) => {
+    const filtered = includeForks ? repos : repos.filter((r) => !r.fork);
+    return sortRepos(filtered, sort).slice(0, limit);
+};
+
+/**
+ * GET /top-repos?username=&sort=stars|updated&limit=6&columns=2&forks=true
+ *
+ * Renders a grid of repo cards for a user's most notable repositories, reusing
+ * the repo-card renderer. Forks are excluded by default; an empty selection
+ * renders a graceful placeholder rather than an error.
+ */
+export default async (req, res) => {
+    const username = typeof req.query.username === 'string' ? req.query.username.trim() : '';
+    if (!username) {
+        return res.status(400).type('text/plain').send('Missing `username`');
+    }
+
+    res.setHeader('Content-Type', 'image/svg+xml');
+
+    try {
+        const token = req.session?.github_token ?? process.env.GITHUB_TOKEN;
+        const client = createGithubClient({ token });
+        const repos = await getRepos(username, client);
+        if (!repos) {
+            return res
+                .status(502)
+                .type('text/plain')
+                .send(`Failed to fetch repositories for ${username}`);
+        }
+
+        const selected = selectRepos(repos, {
+            sort: req.query.sort,
+            limit: parseLimit(req.query.limit),
+            includeForks: isTrue(req.query.forks),
+        });
+
+        const cards = selected.map(toCardData);
+        return res.send(renderTopRepos(cards, { columns: req.query.columns }));
+    } catch (err) {
+        return res
+            .status(502)
+            .type('text/plain')
+            .send(`Failed to fetch repositories: ${err.message}`);
+    }
+};
+
+// Route descriptor for the auto-mounting registry (#52). Mounts at
+// GET /top-repos with no express.js edit once the registry lands — consistent
+// with /repo-card and /repo-tech-badges.
+export const route = { method: 'get', path: '/top-repos', auth: false };
+
+export { parseLimit, isTrue };

--- a/src/tests/top-repos.test.js
+++ b/src/tests/top-repos.test.js
@@ -1,0 +1,233 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { renderTopRepos, clampColumns, CARD_W, GAP } from '../tiles/top-repos.js';
+import handler, { sortRepos, selectRepos, parseLimit, isTrue } from '../../api/top-repos.js';
+
+const NOW = new Date('2026-06-01T00:00:00Z').getTime();
+
+const card = (over = {}) => ({
+    owner: 'octocat',
+    name: 'hello-world',
+    description: 'hi',
+    stars: 10,
+    forks: 2,
+    openIssues: 1,
+    language: 'JavaScript',
+    languageHex: 'f1e05a',
+    updatedAt: '2026-05-30T00:00:00Z',
+    ...over,
+});
+
+describe('clampColumns', () => {
+    test('defaults to 2 for missing/invalid input', () => {
+        expect(clampColumns(undefined)).toBe(2);
+        expect(clampColumns('abc')).toBe(2);
+        expect(clampColumns(0)).toBe(2);
+        expect(clampColumns(-5)).toBe(2);
+    });
+    test('caps at 3 and accepts numeric strings', () => {
+        expect(clampColumns('1')).toBe(1);
+        expect(clampColumns(3)).toBe(3);
+        expect(clampColumns(9)).toBe(3);
+    });
+});
+
+describe('renderTopRepos', () => {
+    test('renders the empty state for no cards', () => {
+        const svg = renderTopRepos([], { now: NOW });
+        expect(svg.startsWith('<svg')).toBe(true);
+        expect(svg).toContain('No repositories to show');
+    });
+
+    test('handles non-array input gracefully', () => {
+        expect(renderTopRepos(undefined, { now: NOW })).toContain('No repositories to show');
+    });
+
+    test('renders one nested card per repo', () => {
+        const svg = renderTopRepos([card({ name: 'alpha' }), card({ name: 'beta' })], { now: NOW });
+        expect(svg).toContain('alpha');
+        expect(svg).toContain('beta');
+        // two nested cards => two card-sized inner <svg> viewports
+        expect(svg.match(new RegExp(`width="${CARD_W}"`, 'g'))).toHaveLength(2);
+    });
+
+    test('lays out a grid: width grows with columns, second row offsets down', () => {
+        const cards = [card(), card(), card()];
+        const svg = renderTopRepos(cards, { columns: 2, now: NOW });
+        const twoCol = 2 * CARD_W + GAP;
+        expect(svg).toContain(`width="${twoCol}"`);
+        // third card wraps to row 2 at x=0
+        expect(svg).toContain('translate(0, 216)');
+    });
+
+    test('single column places cards in one vertical stack', () => {
+        const svg = renderTopRepos([card(), card()], { columns: 1, now: NOW });
+        expect(svg).toContain(`width="${CARD_W}"`);
+        expect(svg).toContain('translate(0, 216)');
+    });
+
+    test('produces a well-formed SVG document', () => {
+        const svg = renderTopRepos([card()], { now: NOW });
+        expect(svg.trimEnd().endsWith('</svg>')).toBe(true);
+        expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+    });
+});
+
+describe('sortRepos', () => {
+    const a = { name: 'a', stargazers_count: 5, pushed_at: '2026-01-01T00:00:00Z' };
+    const b = { name: 'b', stargazers_count: 50, pushed_at: '2026-05-01T00:00:00Z' };
+    const c = { name: 'c', stargazers_count: 1, pushed_at: '2026-06-01T00:00:00Z' };
+
+    test('sorts by stars descending by default', () => {
+        expect(sortRepos([a, b, c]).map((r) => r.name)).toEqual(['b', 'a', 'c']);
+    });
+    test('sorts by most recently pushed when sort=updated', () => {
+        expect(sortRepos([a, b, c], 'updated').map((r) => r.name)).toEqual(['c', 'b', 'a']);
+    });
+    test('does not mutate the input array', () => {
+        const input = [a, b];
+        sortRepos(input);
+        expect(input).toEqual([a, b]);
+    });
+});
+
+describe('selectRepos', () => {
+    const repos = [
+        { name: 'fork-1', fork: true, stargazers_count: 100 },
+        { name: 'owned-1', fork: false, stargazers_count: 50 },
+        { name: 'owned-2', fork: false, stargazers_count: 80 },
+    ];
+
+    test('excludes forks by default', () => {
+        const out = selectRepos(repos, {});
+        expect(out.map((r) => r.name)).toEqual(['owned-2', 'owned-1']);
+    });
+    test('includes forks when opted in', () => {
+        const out = selectRepos(repos, { includeForks: true });
+        expect(out.map((r) => r.name)).toEqual(['fork-1', 'owned-2', 'owned-1']);
+    });
+    test('truncates to the limit', () => {
+        expect(selectRepos(repos, { limit: 1, includeForks: true })).toHaveLength(1);
+    });
+});
+
+describe('parseLimit / isTrue', () => {
+    test('parseLimit defaults, clamps and floors', () => {
+        expect(parseLimit(undefined)).toBe(6);
+        expect(parseLimit('3')).toBe(3);
+        expect(parseLimit('999')).toBe(12);
+        expect(parseLimit('0')).toBe(6);
+        expect(parseLimit('-4')).toBe(6);
+    });
+    test('isTrue recognizes true/1 only', () => {
+        expect(isTrue('true')).toBe(true);
+        expect(isTrue('1')).toBe(true);
+        expect(isTrue('false')).toBe(false);
+        expect(isTrue(undefined)).toBe(false);
+    });
+});
+
+describe('GET /top-repos handler', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    const mockRes = () => ({
+        statusCode: 200,
+        headers: {},
+        body: undefined,
+        status(c) {
+            this.statusCode = c;
+            return this;
+        },
+        type() {
+            return this;
+        },
+        setHeader(k, v) {
+            this.headers[k] = v;
+        },
+        send(b) {
+            this.body = b;
+            return this;
+        },
+    });
+
+    const ghRepo = (over = {}) => ({
+        owner: { login: 'octocat' },
+        name: 'repo',
+        description: 'hi',
+        stargazers_count: 10,
+        forks_count: 2,
+        open_issues_count: 1,
+        language: 'JavaScript',
+        pushed_at: '2026-05-30T00:00:00Z',
+        fork: false,
+        ...over,
+    });
+
+    test('400 when username is missing', async () => {
+        const res = mockRes();
+        await handler({ query: {} }, res);
+        expect(res.statusCode).toBe(400);
+    });
+
+    test('502 when the repo fetch fails (non-OK)', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({ ok: false, status: 404 })),
+        );
+        const res = mockRes();
+        await handler({ query: { username: 'ghost' } }, res);
+        expect(res.statusCode).toBe(502);
+    });
+
+    test('renders a grid SVG for a valid user', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({
+                ok: true,
+                json: async () => [
+                    ghRepo({ name: 'top', stargazers_count: 500 }),
+                    ghRepo({ name: 'mid', stargazers_count: 100 }),
+                ],
+            })),
+        );
+        const res = mockRes();
+        await handler({ query: { username: 'octocat' } }, res);
+        expect(res.statusCode).toBe(200);
+        expect(res.headers['Content-Type']).toBe('image/svg+xml');
+        expect(res.body).toContain('<svg');
+        expect(res.body).toContain('top');
+        expect(res.body).toContain('mid');
+    });
+
+    test('renders the empty state when the user has only forks', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({
+                ok: true,
+                json: async () => [ghRepo({ name: 'forked', fork: true })],
+            })),
+        );
+        const res = mockRes();
+        await handler({ query: { username: 'octocat' } }, res);
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toContain('No repositories to show');
+    });
+
+    test('502 when the fetch throws', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => {
+                throw new Error('network down');
+            }),
+        );
+        const res = mockRes();
+        await handler({ query: { username: 'octocat' } }, res);
+        expect(res.statusCode).toBe(502);
+    });
+});
+
+describe('route descriptor', () => {
+    test('exposes {method, path, auth}', async () => {
+        const { route } = await import('../../api/top-repos.js');
+        expect(route).toMatchObject({ method: 'get', path: '/top-repos', auth: false });
+    });
+});

--- a/src/tiles/top-repos.js
+++ b/src/tiles/top-repos.js
@@ -1,0 +1,63 @@
+import { THEME_CSS } from './theme.js';
+import { renderRepoCard } from './repo-card.js';
+
+// Dimensions of a single repo card (must match src/tiles/repo-card.js).
+const CARD_W = 460;
+const CARD_H = 200;
+const GAP = 16;
+
+/** Clamps the column count to a sensible 1–3 range (default 2). */
+const clampColumns = (value) => {
+    const n = Math.trunc(Number(value));
+    if (!Number.isFinite(n) || n < 1) return 2;
+    return Math.min(n, 3);
+};
+
+/**
+ * Renders the empty state — a single card-sized, theme-aware tile shown when a
+ * user has no repositories to showcase (e.g. all repos are forks).
+ * @returns {string} SVG document
+ */
+const renderEmpty = () =>
+    `<svg width="${CARD_W}" height="${CARD_H}" viewBox="0 0 ${CARD_W} ${CARD_H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="No repositories to show">
+    ${THEME_CSS}
+    <rect x="0.5" y="0.5" width="${CARD_W - 1}" height="${CARD_H - 1}" rx="12" fill="var(--bg2)" stroke="var(--fg15)"/>
+    <text x="${CARD_W / 2}" y="${CARD_H / 2}" text-anchor="middle" dominant-baseline="middle" font-size="15" font-family="Arial, sans-serif" fill="var(--fg60)">No repositories to show</text>
+</svg>`;
+
+/**
+ * Renders a showcase grid of repository cards as a single self-contained,
+ * theme-aware SVG. Each cell reuses {@link renderRepoCard}; cards are laid out
+ * left-to-right, top-to-bottom in `columns` columns. Light/dark is handled by
+ * the per-card THEME_CSS via prefers-color-scheme — no theme argument.
+ *
+ * @param {Array<object>} [cards]  card-data objects in the shape renderRepoCard expects
+ * @param {object} [opts]
+ * @param {number} [opts.columns]  columns in the grid (1–3, default 2)
+ * @param {number} [opts.now]      reference time (epoch ms) forwarded to each card
+ * @returns {string} SVG document
+ */
+export const renderTopRepos = (cards = [], opts = {}) => {
+    if (!Array.isArray(cards) || cards.length === 0) return renderEmpty();
+
+    const now = opts.now ?? Date.now();
+    const cols = Math.min(clampColumns(opts.columns), cards.length);
+    const rows = Math.ceil(cards.length / cols);
+    const width = cols * CARD_W + (cols - 1) * GAP;
+    const height = rows * CARD_H + (rows - 1) * GAP;
+
+    const cells = cards
+        .map((card, i) => {
+            const x = (i % cols) * (CARD_W + GAP);
+            const y = Math.floor(i / cols) * (CARD_H + GAP);
+            return `    <g transform="translate(${x}, ${y})">${renderRepoCard(card, { now })}</g>`;
+        })
+        .join('\n');
+
+    return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Top repositories">
+${cells}
+</svg>`;
+};
+
+export { clampColumns, CARD_W, CARD_H, GAP };
+export default renderTopRepos;


### PR DESCRIPTION
## Summary
Adds the **top-repos showcase** tile for Phase 5 (issue #66).

`GET /top-repos?username=&sort=stars|updated&limit=6&columns=2&forks=true` renders a theme-aware grid of repository cards, reusing the existing `repo-card` renderer.

## Acceptance criteria (#66)
- [x] `GET /top-repos` renders a grid of repo cards reusing the repo-card renderer
- [x] Sortable by stars (default) or recent push; forks excluded by default
- [x] Graceful empty state; exports a route descriptor
- [x] Unit + endpoint tests

## Behavior
- `sort` = `stars` (default) | `updated` (most recently pushed)
- `forks=true|1` opts forks in (excluded otherwise)
- `limit` clamped to [1, 12] (default 6); `columns` clamped to [1, 3] (default 2)
- Empty selection renders a card-sized placeholder, not an error
- `400` on missing username, `502` on fetch failure

## Wiring
Exports a `route` descriptor (`GET /top-repos`, no auth) for the #52 auto-mount registry — same pattern as the `repo-card` / `repo-tech-badges` siblings, so no `express.js` edit is needed.

## Owns
- `api/top-repos.js`
- `src/tiles/top-repos.js`
- `src/tests/top-repos.test.js`

## Tests
Full suite green: 316 passed (22 new top-repos tests). Lint clean (0 errors); new files Prettier-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)