### PR TITLE
docs: sync README, docs/api.md, dev.to.md to current endpoints (closes #56, #57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The application relies on several environment variables for configuration and AP
 | :-------------------------- | :------------------------------------------------------------------------------------------------------ | :----------------------------- |
 | `SESSION_SECRET`            | Secret key used by `express-session` for signing the session ID cookie.                                 | Yes (has dev default)          |
 | `NODE_ENV`                  | Determines if session cookies should be secure (HTTPS only). Set to `production` for secure cookies.    | No (defaults to `development`) |
-| `PORT` or `port`            | The port on which the Express server will listen.                                                       | No (defaults to `8080`)        |
+| `PORT` or `port`            | The port on which the Express server will listen.                                                       | No (defaults to `8088`)        |
 | `GOOGLE_AI_STUDIO_KEY`      | API key for Google's Generative AI Studio (Gemini model) for AI-powered features.                       | Yes (for AI features)          |
 | `GITHUB_TOKEN`              | GitHub Personal Access Token used for accessing GitHub API data without user authentication (fallback). | No (recommended for public API access) |
 | `GITHUB_APP_CLIENT_ID`      | Client ID for your GitHub OAuth App, used for user authentication.                                      | Yes (for GitHub OAuth)         |
@@ -34,7 +34,7 @@ To run the server locally:
     ```bash
     npm start
     ```
-    The server will start on the port specified in `PORT` or `8080` by default.
+    The server will start on the port specified in `PORT` or `8088` by default.
 
 To generate a set of example SVG tiles to the `preview/` directory, configure `preview.config.js` and run:
 
@@ -45,6 +45,8 @@ npm run preview
 ## Endpoints
 
 This section describes the API endpoints, their purpose, accepted query parameters, and examples. Most SVG/data endpoints can be used without user authentication if `GITHUB_TOKEN` is set in your environment, otherwise, they require an authenticated user session. Endpoints that modify GitHub data *always* require an authenticated user session.
+
+The full route list lives in [`api/_routes.js`](api/_routes.js) (the source of truth). Auth-gated endpoints accept **either** a signed-in session cookie **or** an `Authorization: Bearer <token>` header carrying a [minted API token](#api-token-endpoints). The public SVG/data endpoints are **rate-limited** for anonymous traffic (default 60 requests / 60 s per IP+token; configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX` / `RATE_LIMIT_DISABLED`); authenticated sessions are exempt. Over-limit requests get a **429** with `Retry-After` and `X-RateLimit-*` headers. The single-page UI is served at the site root `/` (there is no `/dashboard` route). See [`docs/api.md`](docs/api.md) for the complete reference.
 
 ### Authentication Endpoints
 
@@ -58,7 +60,7 @@ Initiates the GitHub OAuth flow. Redirects the user to GitHub for authorization.
 
 **Example URL:**
 ```
-http://localhost:8080/auth/github
+http://localhost:8088/auth/github
 ```
 
 #### GET /auth/callback
@@ -74,7 +76,7 @@ The callback URI for GitHub OAuth. Exchanges the authorization code for an acces
 
 **Example URL:**
 ```
-http://localhost:8080/auth/callback?code=YOUR_CODE&state=YOUR_STATE
+http://localhost:8088/auth/callback?code=YOUR_CODE&state=YOUR_STATE
 ```
 
 #### GET /auth/logout
@@ -85,7 +87,7 @@ Destroys the user's session, effectively logging them out.
 
 **Example URL:**
 ```
-http://localhost:8080/auth/logout
+http://localhost:8088/auth/logout
 ```
 
 #### GET /auth/me
@@ -96,21 +98,36 @@ Returns JSON data about the currently authenticated GitHub user. Requires an act
 
 **Example URL:**
 ```
-http://localhost:8080/auth/me
+http://localhost:8088/auth/me
 ```
 
-### Dashboard Endpoint
+### API Token Endpoints
 
-#### GET /dashboard
+Long-lived tokens for headless automation (cron, CI). All require an authenticated **session** (you mint a token while signed in), then the token is sent as `Authorization: Bearer <token>` to any auth-gated endpoint. Tokens are stored only as SHA-256 hashes, are in-memory (do not survive a restart), and never expire -- revoke to rotate.
 
-Renders the dashboard HTML page for authenticated users. Requires an active session.
+#### POST /tokens
 
-**Query Parameters:** None.
+Mints a new API token. Optional JSON body `{ "label": "ci" }`. Returns **201** `{ token, id, login, label, createdAt, lastUsedAt }` -- the `token` is shown **exactly once**.
 
-**Example URL:**
-```
-http://localhost:8080/dashboard
-```
+#### GET /tokens
+
+Lists the signed-in user's tokens as metadata (never the secret): `{ tokens: [...] }`.
+
+#### DELETE /tokens/:id
+
+Revokes one of the signed-in user's tokens. **204** on success, `404` for an unknown id.
+
+### Config Endpoints
+
+Manage the `.pretty-readme.json` allowlist in your profile repo. Both require an authenticated session.
+
+#### GET /config
+
+Returns `{ config, exists }` -- the parsed `.pretty-readme.json`, or `null` when absent.
+
+#### PUT /config
+
+Writes the allowlist. JSON body `{ "repos": ["repo-a", "repo-b"] }`. Returns `{ ok: true }`; `400` when `repos` is not an array.
 
 ### Profile Update Endpoint
 
@@ -126,8 +143,70 @@ Generates and pushes various SVG graphics and markdown content to the user's Git
 
 **Example URL (Dry Run):**
 ```
-http://localhost:8080/apply-readme?dry_run=true
+http://localhost:8088/apply-readme?dry_run=true
 ```
+
+#### GET /preview-readme
+
+Generates (or returns cached) the full profile preview -- bio, all SVGs, opt-in account tiles, and the insights markdown -- as JSON. Requires an active session. Pass `refresh=true` to bypass the cache.
+
+**Example URL:**
+```
+http://localhost:8088/preview-readme?refresh=true
+```
+
+#### GET /apply-all
+
+Applies enabled features across selected repos: pushes `SCORE.md` / `README.md` via a per-repo pull request on a `pretty-readme/YYYY-MM-DD` branch, and applies topics/descriptions immediately. Skips repos whose HEAD SHA is unchanged since the last run (tracked in `.pretty-readme-state.json`). Supports Server-Sent Events when the request `Accept`s `text/event-stream`. Requires an active session (or a Bearer API token for cron).
+
+**Query Parameters:**
+
+| Name           | Default | Description |
+| :------------- | :------ | :---------- |
+| `repos`        |         | Comma-separated repo names, or `*` for all eligible repos. When absent, the `.pretty-readme.json` allowlist is required (cron mode). |
+| `score`        | `false` | Generate and push `SCORE.md` per repo (via PR). |
+| `readme`       | `false` | Generate and push `README.md` per repo (via PR). |
+| `topics`       | `false` | Suggest and apply GitHub topics (immediately). |
+| `descriptions` | `false` | Suggest and apply descriptions (immediately). |
+| `workflow`     | `false` | Push a daily `pretty-readme-score.yml` workflow per repo (via PR). |
+
+#### GET /repos
+
+Returns a lightweight JSON list of the authenticated user's repos (`name`, `description`, `language`, `isProfile`, `stars`, `pushedAt`), profile repo first. Requires an active session.
+
+#### GET /repo-scan
+
+Scans a repo (file tree, key files, source samples), grades code quality across six dimensions, and returns the analysis (suggested topics, README outline, prioritised suggestions). Cached per user/repo for 4 hours. Requires an active session.
+
+**Query Parameters:**
+
+| Name      | Default | Description |
+| :-------- | :------ | :---------- |
+| `repo`    |         | **Required.** Repo name. |
+| `refresh` | `false` | `true` forces a fresh scan, bypassing the cache. |
+
+#### GET /repository-readme
+
+Generates a README **preview** for a single repo -- the rendered markdown plus the underlying analysis -- so the UI can preview before applying. Reuses the shared scan cache. Requires an active session.
+
+**Query Parameters:**
+
+| Name      | Default | Description |
+| :-------- | :------ | :---------- |
+| `repo`    |         | **Required.** `repo` or `owner/repo`. |
+| `refresh` | `false` | `true` forces a fresh scan. |
+
+#### GET /repo-apply
+
+Pushes `SCORE.md` directly to a single target repo, optionally a generated `README.md`, and optionally a daily score workflow. Uses cached scan data when available. Requires an active session (or a Bearer token for cron).
+
+**Query Parameters:**
+
+| Name       | Default | Description |
+| :--------- | :------ | :---------- |
+| `repo`     |         | **Required.** `repo` or `owner/repo`. |
+| `readme`   | `false` | Also generate and push `README.md` from the scan outline. |
+| `workflow` | `false` | Push `.github/workflows/pretty-readme-score.yml` (daily, 05:00 UTC) if absent. |
 
 ### Monkeytype Connection Endpoints
 
@@ -146,7 +225,7 @@ Connects a Monkeytype API key to the user's session. This key is then used for `
 
 **Example (using `curl`):**
 ```bash
-curl -X POST -H "Content-Type: application/json" -d '{"api_key": "YOUR_API_KEY", "username": "YourMTUsername"}' http://localhost:8080/monkeytype/connect
+curl -X POST -H "Content-Type: application/json" -d '{"api_key": "YOUR_API_KEY", "username": "YourMTUsername"}' http://localhost:8088/monkeytype/connect
 ```
 
 #### POST /monkeytype/disconnect
@@ -157,8 +236,31 @@ Removes the Monkeytype API key and username from the user's session.
 
 **Example (using `curl`):**
 ```bash
-curl -X POST http://localhost:8080/monkeytype/disconnect
+curl -X POST http://localhost:8088/monkeytype/disconnect
 ```
+
+### WakaTime Connection Endpoints
+
+These endpoints connect a WakaTime API key to your session for `GET /wakatime`. They mirror the Monkeytype connect/disconnect endpoints.
+
+#### POST /wakatime/connect
+
+Stores a WakaTime API key on the session.
+
+**Request Body Parameters:**
+
+| Name      | Default | Description |
+| :-------- | :------ | :---------- |
+| `api_key` |         | **Required.** Your WakaTime API key. `400` when missing. |
+
+**Example (using `curl`):**
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"api_key": "waka_..."}' http://localhost:8088/wakatime/connect
+```
+
+#### POST /wakatime/disconnect
+
+Removes the WakaTime API key from the session. The `WAKATIME_API_KEY` env fallback (if set) remains in effect.
 
 ### SVG / Data Endpoints
 
@@ -178,9 +280,9 @@ Generates an SVG image displaying a developer account summary.
 
 **Example URLs:**
 ```
-http://localhost:8080/account-summary?username=octocat&background=cherry-blossom
-http://localhost:8080/account-summary?username=octocat&projects=top5
-http://localhost:8080/account-summary?username=octocat&projects=my-repo-1,my-repo-2
+http://localhost:8088/account-summary?username=octocat&background=cherry-blossom
+http://localhost:8088/account-summary?username=octocat&projects=top5
+http://localhost:8088/account-summary?username=octocat&projects=my-repo-1,my-repo-2
 ```
 
 #### GET /account-summary-md
@@ -191,7 +293,7 @@ Generates a plain text developer bio summary based on the authenticated user's r
 
 **Example URL:**
 ```
-http://localhost:8080/account-summary-md
+http://localhost:8088/account-summary-md
 ```
 
 #### GET /developer-rating
@@ -202,7 +304,7 @@ Generates an SVG image displaying the developer rating for the authenticated use
 
 **Example URL:**
 ```
-http://localhost:8080/developer-rating
+http://localhost:8088/developer-rating
 ```
 
 #### GET /developer-rating-insights
@@ -213,7 +315,38 @@ Generates a detailed Markdown report with developer rating insights and actionab
 
 **Example URL:**
 ```
-http://localhost:8080/developer-rating-insights
+http://localhost:8088/developer-rating-insights
+```
+
+#### GET /contribution-graph
+
+Generates an SVG contribution heatmap with current-streak, longest-streak, and total-contribution figures, sourced from the GitHub GraphQL contribution calendar.
+
+**Query Parameters:**
+
+| Name         | Default | Description |
+| :----------- | :------ | :---------- |
+| `username`   |         | GitHub username (falls back to the session user). |
+| `background` | `null`  | Theme: `cherry-blossom`, `geometric`, or `vapor-wave` (alias: `theme`). |
+
+**Example URL:**
+```
+http://localhost:8088/contribution-graph?username=octocat&background=geometric
+```
+
+#### GET /stats-card
+
+Generates an SVG stats card -- total stars, commits, pull requests, issues, followers, and repositories contributed to -- aggregated from the GitHub GraphQL API.
+
+**Query Parameters:**
+
+| Name       | Default | Description |
+| :--------- | :------ | :---------- |
+| `username` |         | GitHub username (falls back to the session user). |
+
+**Example URL:**
+```
+http://localhost:8088/stats-card?username=octocat
 ```
 
 #### GET /tech-summary
@@ -231,8 +364,8 @@ Generates an SVG image displaying a summary of the top technologies used by a us
 
 **Example URLs:**
 ```
-http://localhost:8080/tech-summary?background=geometric&limit=10&sort=frequency
-http://localhost:8080/tech-summary?background=vapor-wave&exclude=JavaScript,HTML
+http://localhost:8088/tech-summary?background=geometric&limit=10&sort=frequency
+http://localhost:8088/tech-summary?background=vapor-wave&exclude=JavaScript,HTML
 ```
 
 #### GET /tech-list
@@ -248,8 +381,8 @@ Returns a JSON list of technologies used by the authenticated user (or user asso
 
 **Example URLs:**
 ```
-http://localhost:8080/tech-list?sort=alpha
-http://localhost:8080/tech-list?exclude=CSS,Markdown
+http://localhost:8088/tech-list?sort=alpha
+http://localhost:8088/tech-list?exclude=CSS,Markdown
 ```
 
 #### GET /tech-chart
@@ -264,8 +397,8 @@ Generates an SVG chart visualizing programming language usage.
 
 **Example URLs:**
 ```
-http://localhost:8080/tech-chart?chart=donut
-http://localhost:8080/tech-chart?chart=spider
+http://localhost:8088/tech-chart?chart=donut
+http://localhost:8088/tech-chart?chart=spider
 ```
 
 #### GET /tech-spider
@@ -285,10 +418,10 @@ Generates a technology visualization SVG. This versatile endpoint can render spi
 
 **Example URLs:**
 ```
-http://localhost:8080/tech-spider?type=spider&categories=languages,databases,devops&limit=5
-http://localhost:8080/tech-spider?type=treemap&categories=languages,frameworks,cloud&limit=8
-http://localhost:8080/tech-spider?type=cards&categories=languages,frameworks,ai,databases&limit=12
-http://localhost:8080/tech-spider?type=grid&categories=languages,frameworks,cloud,ai&columns=2
+http://localhost:8088/tech-spider?type=spider&categories=languages,databases,devops&limit=5
+http://localhost:8088/tech-spider?type=treemap&categories=languages,frameworks,cloud&limit=8
+http://localhost:8088/tech-spider?type=cards&categories=languages,frameworks,ai,databases&limit=12
+http://localhost:8088/tech-spider?type=grid&categories=languages,frameworks,cloud,ai&columns=2
 ```
 
 #### GET /tech-categories
@@ -303,7 +436,7 @@ Returns a JSON list of technology categories that have at least one detected tec
 
 **Example URL:**
 ```
-http://localhost:8080/tech-categories?limit=5
+http://localhost:8088/tech-categories?limit=5
 ```
 
 #### GET /improve-topics
@@ -318,7 +451,7 @@ Uses AI to suggest and apply GitHub topics to repositories that have fewer than 
 
 **Example URL (Dry Run):**
 ```
-http://localhost:8080/improve-topics?dry_run=true
+http://localhost:8088/improve-topics?dry_run=true
 ```
 
 #### GET /improve-descriptions
@@ -333,7 +466,7 @@ Uses AI to suggest and apply descriptions to owned GitHub repositories that curr
 
 **Example URL (Dry Run):**
 ```
-http://localhost:8080/improve-descriptions?dry_run=true
+http://localhost:8088/improve-descriptions?dry_run=true
 ```
 
 #### GET /monkeytype
@@ -344,7 +477,33 @@ Generates an SVG chart visualizing Monkeytype typing speed personal bests across
 
 **Example URL:**
 ```
-http://localhost:8080/monkeytype
+http://localhost:8088/monkeytype
+```
+
+#### GET /wakatime
+
+Generates an SVG chart of coding time by language from the WakaTime API. Resolves the key from the session (`POST /wakatime/connect`) or the `WAKATIME_API_KEY` env var. `401` when no key is connected; `404` when the range has no data.
+
+**Query Parameters:**
+
+| Name    | Default       | Description |
+| :------ | :------------ | :---------- |
+| `range` | `last_7_days` | `last_7_days`, `last_30_days`, `last_6_months`, `last_year`, or `all_time`. |
+
+**Example URL:**
+```
+http://localhost:8088/wakatime?range=last_30_days
+```
+
+### Health
+
+#### GET /healthz
+
+Liveness/health probe. Unauthenticated, dependency-free, and never rate-limited (useful for Cloud Run health checks). Returns **200** `{ "status": "ok", "version": "<package version>" }`.
+
+**Example URL:**
+```
+http://localhost:8088/healthz
 ```
 
 ## Automated Updates (Cron Job)
@@ -400,8 +559,8 @@ you want to `true`:
 | :------------------ | :------ |
 | `contributionGraph` | Contribution heatmap + current/longest streak (`/contribution-graph`). |
 | `statsCard`         | Stars / commits / PRs / issues / followers / contributed-to card (`/stats-card`). |
-| `languageTrend`     | Cumulative language-usage-over-time stacked area chart (`/language-trend`). |
-| `socialLinks`       | Brand badges linking to your social profiles (`/social-links`), built from the `social` map below. |
+| `languageTrend`     | Cumulative language-usage-over-time stacked area chart (rendered at apply time; no standalone endpoint yet). |
+| `socialLinks`       | Brand badges linking to your social profiles, built from the `social` map below (rendered at apply time; no standalone endpoint yet). |
 
 The `socialLinks` tile reads the top-level `social` map — `platform: handle`
 pairs (e.g. `github`, `twitter`/`x`, `linkedin`, `devto`, `mastodon`, `email`,

--- a/dev.to.md
+++ b/dev.to.md
@@ -9,6 +9,8 @@ Your GitHub profile README is usually a snapshot frozen in time. You set it up o
 - An **AI-written bio** — regenerated from your real commit history, not a template
 - **SCORE.md** per repo — a code quality report graded A–F across six dimensions
 - **AI topics and descriptions** for repos that are missing them
+- **Account tiles** -- an opt-in contribution heatmap (with streaks), a GitHub stats card, a language-trend chart, and social-link badges
+- **Typing & coding stats** -- optional Monkeytype WPM and WakaTime coding-time charts
 
 Everything outputs as SVG or Markdown, embeds directly into any README, and can run on a daily cron so it's always current.
 
@@ -58,7 +60,7 @@ GITHUB_APP_CLIENT_SECRET=your-oauth-app-client-secret
 BASE_URL=http://localhost:8080
 ```
 
-For your GitHub OAuth App, set the callback URL to `http://localhost:8080/auth/callback`.
+For your GitHub OAuth App, set the callback URL to `http://localhost:8088/auth/callback`.
 
 ### 3 — Start the server
 
@@ -66,7 +68,7 @@ For your GitHub OAuth App, set the callback URL to `http://localhost:8080/auth/c
 npm start
 ```
 
-Open `http://localhost:8080`. Sign in with GitHub and you'll land on the preview dashboard.
+Open `http://localhost:8088`. Sign in with GitHub and you'll land on the preview dashboard.
 
 ---
 
@@ -89,9 +91,20 @@ Every graphic is also available as a plain URL you can drop into any markdown fi
 
 <!-- Tech cards grid -->
 ![Tech Stack](https://your-service.run.app/tech-spider?type=cards&categories=languages,frameworks,ai&limit=12)
+
+<!-- Contribution heatmap + streaks -->
+![Contribution Graph](https://your-service.run.app/contribution-graph?username=octocat)
+
+<!-- GitHub stats card -->
+![GitHub Stats](https://your-service.run.app/stats-card?username=octocat)
+
+<!-- WakaTime coding time (requires a connected WakaTime key) -->
+![Coding Time](https://your-service.run.app/wakatime?range=last_30_days)
 ```
 
 The SVGs are themed and adapt to GitHub's light and dark mode automatically.
+
+> The public SVG/data endpoints are rate-limited for anonymous traffic (default 60 requests / 60 s per IP + token; tune via `RATE_LIMIT_MAX` / `RATE_LIMIT_WINDOW_MS`). Signed-in sessions and the `/healthz` probe are exempt. Over-limit requests get a `429` with `Retry-After` and `X-RateLimit-*` headers. The web UI is served at the site root `/`.
 
 ### Pushing your profile README
 
@@ -187,7 +200,7 @@ jobs:
       - name: Update profile and open repo PRs
         run: |
           curl -fsSL \
-            -H "Cookie: session=${{ secrets.PRETTY_README_SESSION }}" \
+            -H "Authorization: Bearer ${{ secrets.PRETTY_README_TOKEN }}" \
             "${{ secrets.PRETTY_README_URL }}/apply-all?score=true&readme=true&topics=true&descriptions=true"
 ```
 
@@ -207,16 +220,15 @@ Go to your profile repo → **Settings → Secrets and variables → Actions** a
 | Secret | Value |
 |:--|:--|
 | `PRETTY_README_URL` | Your deployed service URL, e.g. `https://github-pretty-readme-abc123-uc.a.run.app` |
-| `PRETTY_README_SESSION` | Your session cookie — see below |
+| `PRETTY_README_TOKEN` | A long-lived API token (see below) |
 
-**Getting the session cookie:**
+**Minting an API token:**
 
 1. Sign into the service in your browser
-2. Open DevTools → Application → Cookies → your service domain
-3. Copy the value of the `session` cookie
-4. Paste it as the `PRETTY_README_SESSION` secret
+2. Mint a token with `POST /tokens` (the plaintext token is returned **once** -- copy it immediately)
+3. Paste it as the `PRETTY_README_TOKEN` secret
 
-> Session cookies expire after 7 days. You'll need to re-copy the value after each re-login. A future version will support a long-lived API token to avoid this — for now it's the tradeoff for using the same cookie-session auth as the UI.
+> API tokens do not expire, so there is no more re-copying a session cookie every week. They are sent as `Authorization: Bearer <token>`, are stored only as SHA-256 hashes server-side, and are revocable any time with `DELETE /tokens/:id` -- rotate by minting a new one and deleting the old. The old copied-session-cookie path has been retired: a bare `Authorization: Bearer <anything>` is no longer trusted, since the service now verifies the token against its store.
 
 ### Step 4 — Watch the PRs roll in
 
@@ -271,7 +283,7 @@ The GitHub OAuth App callback URL needs to be updated to your Cloud Run URL: `ht
 
 The project is open source: [github.com/kevinthelago/github-pretty-readme](https://github.com/kevinthelago/github-pretty-readme)
 
-PRs welcome — especially around the session cookie expiry problem for cron jobs, and expanding the code quality scoring dimensions.
+PRs welcome — especially around expanding the code quality scoring dimensions and the optional profile tiles (contribution graph, stats card, WakaTime, language trend, social links).
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,49 @@
 # API Reference
 
-Full reference for all HTTP endpoints exposed by `github-pretty-readme`. Most SVG/data endpoints can be used without user authentication if `GITHUB_TOKEN` is set in the environment; otherwise they require an authenticated user session. Endpoints that modify GitHub data always require an authenticated session.
+Full reference for every HTTP endpoint exposed by `github-pretty-readme`. The
+routes are defined declaratively in [`api/_routes.js`](../api/_routes.js) -- that
+manifest is the source of truth; this document mirrors it.
 
-Base URL (local): `http://localhost:8080`
+Base URL (local): `http://localhost:8088`
+
+## Authentication model
+
+Three kinds of endpoints, distinguished by the `auth` / `rateLimit` flags in the
+route manifest:
+
+- **Auth-gated** (`auth: true`) -- gated by `requireAuth`. The caller must present
+  **either** a signed-in session cookie **or** an `Authorization: Bearer <token>`
+  header carrying a minted API token (see [API tokens](#api-tokens)). A bare or
+  invalid Bearer value is rejected with `401`; a browser with no credentials is
+  redirected to `/`. These endpoints mutate GitHub data or expose account-scoped data.
+- **Public, rate-limited** (`rateLimit: true`) -- usable anonymously. They resolve a
+  GitHub token from the session, an `Authorization: Bearer` PAT, or the
+  `GITHUB_TOKEN` env fallback (in that order). Anonymous traffic is throttled by the
+  [rate limiter](#rate-limiting); authenticated sessions are exempt.
+- **Unguarded** -- `/auth/*`, the `connect`/`disconnect` session endpoints, and
+  `/healthz` carry neither flag.
+
+Image endpoints always respond with `Content-Type: image/svg+xml`, returning a
+themed **error tile** (HTTP 200, so the SVG paints inside an `<img>`) instead of a
+4xx/5xx body when something fails. JSON endpoints use the envelope
+`{ "error": { "code", "message" } }`.
+
+> The single-page app is served at the site root `/` (static files from
+> `public/`). There is **no `/dashboard` route**.
+
+## Rate limiting
+
+Public endpoints flagged `rateLimit` run behind a fixed-window in-memory limiter:
+
+- Key: client IP + Bearer token, so distinct callers/tokens get independent budgets.
+- Defaults: **60 requests / 60 s** per key. Configure with `RATE_LIMIT_WINDOW_MS`,
+  `RATE_LIMIT_MAX`, and `RATE_LIMIT_DISABLED=true` to turn it off.
+- Authenticated sessions (a session GitHub token) are **exempt**. `/healthz` is
+  always exempt.
+- Every response carries `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and
+  `X-RateLimit-Reset` headers. Over-limit returns **429** with a `Retry-After`
+  header -- an error SVG when the client `Accept`s an image, otherwise
+  `{ "error": "Too many requests", "retryAfter": <seconds> }`.
 
 ---
 
@@ -10,150 +51,236 @@ Base URL (local): `http://localhost:8080`
 
 ### GET /auth/github
 
-Initiates the GitHub OAuth flow. Redirects the user to GitHub for authorization.
+Initiates the GitHub OAuth flow (requests `repo` scope) and redirects to GitHub.
+Returns `500` if `GITHUB_APP_CLIENT_ID` / `GITHUB_APP_CLIENT_SECRET` are unset.
 
 **Parameters:** None.
 
----
-
 ### GET /auth/callback
 
-Exchanges the OAuth authorization code for an access token and stores user info in the session.
+Exchanges the OAuth authorization code for an access token and stores the user in
+the session, then redirects to `/`. On error redirects to `/?error=...`.
 
 | Parameter | Description |
 | :-------- | :---------- |
 | `code`    | Authorization code provided by GitHub. |
-| `state`   | OAuth state parameter for CSRF protection. |
-
----
+| `state`   | OAuth state for CSRF protection (must match the value set on `/auth/github`). |
 
 ### GET /auth/logout
 
-Destroys the user session.
-
----
+Clears the session and redirects to `/`.
 
 ### GET /auth/me
 
-Returns JSON about the currently authenticated GitHub user. Requires an active session.
+Returns JSON about the signed-in user:
+`{ username, avatar, name, monkeytype_connected, monkeytype_username }`.
+`401` when not authenticated.
 
 ---
 
-## Dashboard
+## API tokens
 
-### GET /dashboard
+Long-lived tokens for headless automation (cron, CI) so callers no longer copy a
+session cookie. All three endpoints require an **authenticated session** -- you mint
+a token while signed in, then send it as `Authorization: Bearer <token>` to any
+auth-gated endpoint. A token maps to the GitHub access token the apply pipeline
+acts with, so presenting it is equivalent to that user being signed in. Tokens are
+stored as SHA-256 hashes (the plaintext is shown once), are in-memory (do not
+survive a restart), and never expire -- revoke to rotate.
 
-Renders the dashboard HTML page. Requires an active session.
+### POST /tokens
+
+Mint a new token for the signed-in user.
+
+| Body field | Default | Description |
+| :--------- | :------ | :---------- |
+| `label`    | `""`    | Optional human label (truncated to 100 chars). |
+
+Returns **201** `{ token, id, login, label, createdAt, lastUsedAt }`. The `token`
+is returned **exactly once**. `401` when not session-authenticated.
+
+### GET /tokens
+
+Lists the signed-in user's tokens as metadata (never the secret):
+`{ tokens: [{ id, login, label, createdAt, lastUsedAt }] }`. `401` when not authenticated.
+
+### DELETE /tokens/:id
+
+Revokes one of the signed-in user's tokens. **204** on success, `404` for an unknown
+id, `401` when not authenticated.
 
 ---
 
-## Profile Update
+## Allowlist config (auth)
+
+Reads/writes `.pretty-readme.json` in the user's profile repo (`{username}/{username}`).
+
+### GET /config
+
+Returns `{ config, exists }` where `config` is the parsed `.pretty-readme.json`
+(or `null` when absent).
+
+### PUT /config
+
+Writes the allowlist. Body: `{ "repos": ["repo-a", "repo-b"] }`. `400` when `repos`
+is not an array. Returns `{ ok: true }`.
+
+
+---
+
+## Profile preview & apply (auth)
+
+### GET /preview-readme
+
+Generates (or returns cached) the full profile preview: bio, all SVGs, opt-in
+account tiles, and the insights markdown. Returns
+`{ ok, cached, bio, ratingSvg, techGridSvg, monkeytypeSvg, accountTiles, insightsMd }`.
+
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `refresh` | `false` | `true` bypasses the preview cache and regenerates. |
 
 ### GET /apply-readme
 
-Generates and pushes SVG graphics and markdown content to the user's GitHub profile README repository (`{username}/{username}`). Requires an active session with `repo` scope.
+Generates and pushes the profile assets (bio, developer-rating SVG, tech grid,
+language badges, opt-in account tiles, `DEVELOPER_INSIGHTS.md`) plus an
+`update-profile.yml` workflow to the user's profile repo (`{username}/{username}`),
+injecting each between its README markers. Supports **Server-Sent Events** when the
+request `Accept`s `text/event-stream`. Opt-in account tiles enabled in
+`.pretty-readme.json` (`tiles.contributionGraph`, `tiles.statsCard`,
+`tiles.languageTrend`, `tiles.socialLinks`) are rendered, pushed to `assets/`, and
+injected between their markers.
 
-Opt-in account tiles enabled in `.pretty-readme.json` (`tiles.contributionGraph`, `tiles.statsCard`, …) are rendered, pushed to `assets/`, and injected between their README markers. See [README → Opt-in profile tiles](../README.md#opt-in-profile-tiles).
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `dry_run` | `false` | `true` runs without writing to GitHub; the response `tiles` array lists the enabled account-tile ids. |
 
-| Parameter  | Default | Description |
-| :--------- | :------ | :---------- |
-| `dry_run`  | `false` | If `true`, runs without writing to GitHub and returns generated content. The response's `tiles` array lists the enabled account-tile ids. |
-
----
+> Besides a session cookie or minted API token, this endpoint also accepts a raw
+> `Authorization: Bearer <PAT>` directly (verified via a `GET /user` call) for
+> scheduled-workflow callers.
 
 ### GET /apply-all
 
-Applies all enabled features (score reports, README, topics, descriptions) across selected repositories. Supports Server-Sent Events for progress streaming when the `Accept: text/event-stream` header is present.
+Applies enabled features (score reports, READMEs, topics, descriptions, workflow)
+across selected repos, opening a PR per repo on a `pretty-readme/YYYY-MM-DD` branch
+for file changes and applying topics/descriptions immediately. Skips repos whose
+HEAD SHA is unchanged since the last run (tracked in `.pretty-readme-state.json`).
+Supports **Server-Sent Events** when the request `Accept`s `text/event-stream`.
 
-| Parameter       | Default | Description |
-| :-------------- | :------ | :---------- |
-| `repos`         |         | Comma-separated repo names, or `*` for all repos. |
-| `score`         | `false` | Generate and push a SCORE.md for each repo. |
-| `readme`        | `false` | Generate and push a README.md for each repo. |
-| `topics`        | `false` | Suggest and apply GitHub topics for each repo. |
-| `descriptions`  | `false` | Suggest and apply descriptions for each repo. |
-
----
-
-## Monkeytype
-
-### POST /monkeytype/connect
-
-Stores a Monkeytype API key in the session.
-
-| Body field  | Description |
-| :---------- | :---------- |
-| `api_key`   | Your Monkeytype API key. |
-| `username`  | Your Monkeytype username (optional). |
+| Parameter      | Default | Description |
+| :------------- | :------ | :---------- |
+| `repos`        |         | Comma-separated repo names, or `*` for all eligible repos. **Absent** requires the `.pretty-readme.json` allowlist (cron mode). |
+| `score`        | `false` | Generate and push `SCORE.md` per repo (via PR). |
+| `readme`       | `false` | Generate and push `README.md` per repo (via PR). |
+| `topics`       | `false` | Suggest and apply GitHub topics (immediately). |
+| `descriptions` | `false` | Suggest and apply descriptions (immediately). |
+| `workflow`     | `false` | Push a daily `pretty-readme-score.yml` workflow per repo (via PR). |
 
 ---
 
-### POST /monkeytype/disconnect
+## Repository scan & README (auth)
 
-Removes the Monkeytype API key from the session.
+### GET /repos
+
+Returns a lightweight list of the user's repos
+(`{ name, description, language, isProfile, stars, pushedAt }`), profile repo first
+then by most recent push.
+
+### GET /repo-scan
+
+Scans a repo (file tree, key files, source samples), grades code quality across six
+dimensions, and returns the analysis (suggested topics, README outline, prioritised
+suggestions). Cached per user/repo for 4 hours.
+
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `repo`    |         | **Required.** Repo name. |
+| `refresh` | `false` | `true` forces a fresh scan, bypassing the cache. |
+
+### GET /repository-readme
+
+Generates a README **preview** for a single repo: returns the rendered markdown plus
+the underlying analysis (so the UI can preview before applying). Reuses the shared
+scan cache. When the analysis has no README outline, `markdown` is `null`.
+
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `repo`    |         | **Required.** `repo` or `owner/repo` (cache keyed by bare name). |
+| `refresh` | `false` | `true` forces a fresh scan. |
+
+Responses: `200 { markdown, analysis }`; `400` missing `repo`; `401` unauthenticated;
+`404` repo not found; `500` otherwise.
+
+### GET /repo-apply
+
+Pushes `SCORE.md` to the target repo (committed directly, not via PR), optionally a
+generated `README.md`, and optionally a daily score workflow. Uses cached scan data
+when available. Also accepts a raw `Authorization: Bearer <token>` for scheduled
+GitHub Actions callers (derives the user from `owner/repo`, else a `GET /user` call).
+
+| Parameter  | Default | Description |
+| :--------- | :------ | :---------- |
+| `repo`     |         | **Required.** `repo` or `owner/repo`. |
+| `readme`   | `false` | Also generate and push `README.md` from the scan outline. |
+| `workflow` | `false` | Push `.github/workflows/pretty-readme-score.yml` (daily, 05:00 UTC) if absent. |
+
 
 ---
 
-## SVG / Data Endpoints
+## SVG / data endpoints (public, rate-limited)
 
 ### GET /account-summary
 
-Generates an SVG developer account summary.
+Generates an SVG developer account summary (AI-written).
 
 | Parameter    | Default | Description |
 | :----------- | :------ | :---------- |
 | `username`   |         | GitHub username (required if not authenticated). |
 | `background` | `null`  | Theme: `cherry-blossom`, `geometric`, or `vapor-wave`. |
-| `projects`   | `all`   | Number (e.g. `5`) or comma-separated repo names. |
+| `projects`   | `all`   | A number (top-N by stars, e.g. `5`) or a comma-separated list of repo names. |
 
----
+**Example:**
+```
+http://localhost:8088/account-summary?username=octocat&background=cherry-blossom
+http://localhost:8088/account-summary?username=octocat&projects=5
+```
 
 ### GET /account-summary-md
 
-Returns a plain-text developer bio summary for the authenticated user.
-
----
+Returns a plain-text (third-person) developer bio for the resolved user. No params.
 
 ### GET /developer-rating
 
-Generates an SVG developer rating card.
-
----
+Generates an SVG developer-rating card (Breadth, Depth, Diversity, Activity, Impact,
+plus Engineering when workflow metrics are available). No params.
 
 ### GET /developer-rating-insights
 
-Generates a Markdown report with developer rating insights and recommendations.
-
----
+Returns a Markdown report: overall score, weighted dimension table, per-dimension
+breakdowns, and AI recommendations. No params.
 
 ### GET /contribution-graph
 
-Generates an SVG contribution heatmap (a 53×7 calendar) with current-streak,
-longest-streak, and total-contribution figures, sourced from the GitHub GraphQL
-contribution calendar.
+Generates an SVG contribution heatmap with current/longest streak and total
+contributions, sourced from the GitHub GraphQL contribution calendar.
 
 | Parameter    | Default | Description |
 | :----------- | :------ | :---------- |
-| `username`   |         | GitHub username (required if not authenticated). |
+| `username`   |         | GitHub username (falls back to the session user). |
 | `background` | `null`  | Theme: `cherry-blossom`, `geometric`, or `vapor-wave` (alias: `theme`). |
-
----
 
 ### GET /stats-card
 
-Generates an SVG stats card — total stars, commits, pull requests, issues,
-followers, and repositories contributed to — aggregated from the GitHub GraphQL
-API. Adapts to light/dark mode via `prefers-color-scheme`.
+Generates an SVG stats card -- total stars, commits, PRs, issues, followers, and
+repos contributed to -- from aggregated GraphQL user stats.
 
 | Parameter  | Default | Description |
 | :--------- | :------ | :---------- |
-| `username` |         | GitHub username (required if not authenticated). |
-
----
+| `username` |         | GitHub username (falls back to the session user). |
 
 ### GET /tech-summary
 
-Generates an SVG icon grid of top technologies.
+Generates an SVG icon grid of top technologies (languages with a known icon).
 
 | Parameter    | Default     | Description |
 | :----------- | :---------- | :---------- |
@@ -162,87 +289,120 @@ Generates an SVG icon grid of top technologies.
 | `sort`       | `frequency` | `frequency` or `alpha`. |
 | `exclude`    | `null`      | Comma-separated technology names to exclude. |
 
----
-
 ### GET /tech-list
 
-Returns a JSON list of detected technologies with counts and icon metadata.
+Returns a JSON list of detected technologies with counts and icon metadata
+(`[{ language, count, slug, hex }]`).
 
 | Parameter | Default     | Description |
 | :-------- | :---------- | :---------- |
 | `sort`    | `frequency` | `frequency` or `alpha`. |
 | `exclude` | `null`      | Comma-separated names to exclude. |
 
----
-
 ### GET /tech-chart
 
-Generates an SVG language usage chart.
+Generates an SVG language-usage chart.
 
 | Parameter | Default | Description |
 | :-------- | :------ | :---------- |
 | `chart`   | `donut` | `donut` or `spider`. |
 
----
-
 ### GET /tech-spider
 
-Versatile technology visualization (spider chart, treemap, or cards).
+Versatile technology visualization (spider chart, treemap, cards, or grid).
 
 | Parameter    | Default                      | Description |
 | :----------- | :--------------------------- | :---------- |
 | `type`       | `spider`                     | `spider`, `treemap`, `cards`, or `grid`. |
-| `categories` | `languages,frameworks,cloud` | Comma-separated category keys. |
-| `limit`      | `6`                          | Max technologies per category. |
+| `categories` | `languages,frameworks,cloud` | Comma-separated category keys (`languages`, `frameworks`, `cloud`, `ai`, `databases`, `devops`). |
+| `limit`      | `6`                          | Max technologies per category (1-16). |
 | `exclude`    | `null`                       | Comma-separated names to exclude. |
-| `columns`    | `2`                          | Grid columns (only for `type=grid`, max 4). |
-| `title`      | `TECH RADAR`                 | Custom visualization title. |
-
----
+| `columns`    | `2`                          | Grid columns (1-4; used by `type=grid`). |
+| `title`      | `null`                       | Custom visualization title. |
 
 ### GET /tech-categories
 
-Returns a JSON list of technology categories that have ≥1 detected technology.
+Returns a JSON list of tech categories that have at least one detected technology
+(`[{ category, label, color, count }]`).
 
 | Parameter | Default | Description |
 | :-------- | :------ | :---------- |
 | `limit`   | `8`     | Max technologies per category to consider. |
 
----
-
-### GET /monkeytype
-
-Generates an SVG typing speed chart from Monkeytype personal bests. Requires a connected Monkeytype API key.
-
----
-
-## Repository Improvement
-
 ### GET /improve-topics
 
-Uses AI to suggest and apply GitHub topics to under-tagged repos.
+Uses AI to suggest and apply GitHub topics to under-tagged repos (fewer than 3
+topics, non-archived, non-fork). Returns a JSON summary of updated/skipped/errored
+repos.
 
 | Parameter | Default | Description |
 | :-------- | :------ | :---------- |
-| `dry_run` | `false` | If `true`, returns suggestions without applying. |
-
----
+| `dry_run` | `false` | `true` returns suggestions without applying. |
 
 ### GET /improve-descriptions
 
-Uses AI to suggest and apply descriptions to repos that lack them.
+Uses AI to suggest and apply descriptions to repos that lack one (non-archived,
+non-fork). Returns a JSON summary.
 
 | Parameter | Default | Description |
 | :-------- | :------ | :---------- |
-| `dry_run` | `false` | If `true`, returns suggestions without applying. |
+| `dry_run` | `false` | `true` returns suggestions without applying. |
+
+### GET /monkeytype
+
+Generates an SVG typing-speed chart from Monkeytype personal bests (standard English
+time modes). Resolves the API key from the session or `MONKEYTYPE_API_KEY`. Returns
+an error tile when no key is connected or no data is available. No params.
+
+### GET /wakatime
+
+Generates an SVG chart of coding time by language from the WakaTime API. Resolves
+the key from the session or `WAKATIME_API_KEY`. `401` when no key is connected;
+`404` when the range has no data.
+
+| Parameter | Default        | Description |
+| :-------- | :------------- | :---------- |
+| `range`   | `last_7_days`  | `last_7_days`, `last_30_days`, `last_6_months`, `last_year`, or `all_time`. |
 
 ---
 
-### GET /account-summary-md
+## Monkeytype connection
 
-Generates a Markdown code quality score report for a GitHub repository.
+### POST /monkeytype/connect
 
-| Parameter | Default | Description |
-| :-------- | :------ | :---------- |
-| `owner`   |         | Repository owner (GitHub username or org). |
-| `repo`    |         | Repository name. |
+Stores a Monkeytype API key on the session.
+
+| Body field | Description |
+| :--------- | :---------- |
+| `api_key`  | **Required.** Monkeytype API key. `400` when missing. |
+| `username` | Optional Monkeytype username (for linking). |
+
+### POST /monkeytype/disconnect
+
+Clears the session Monkeytype key/username.
+
+---
+
+## WakaTime connection
+
+### POST /wakatime/connect
+
+Stores a WakaTime API key on the session.
+
+| Body field | Description |
+| :--------- | :---------- |
+| `api_key`  | **Required.** WakaTime API key. `400` when missing. |
+
+### POST /wakatime/disconnect
+
+Clears the session WakaTime key. The `WAKATIME_API_KEY` env fallback remains in
+effect for shared/server-wide access.
+
+---
+
+## Health
+
+### GET /healthz
+
+Liveness/health probe. Unauthenticated, dependency-free, and never rate-limited.
+Returns **200** `{ "status": "ok", "version": "<package version>" }`.


### PR DESCRIPTION
Syncs `README.md`, `docs/api.md`, and `dev.to.md` to the true current endpoint surface, derived from `api/_routes.js` (the route source of truth) and each handler. Docs-only; no source changes.

## #56 -- README.md + docs/api.md cover all endpoints

**`docs/api.md` rewritten** to mirror the manifest, with an auth model section (auth-gated = session cookie OR `Authorization: Bearer <minted token>`), a rate-limiting section (60 req / 60 s default, `X-RateLimit-*` + `Retry-After` headers, sessions/`/healthz` exempt), and per-endpoint method / auth / query params for every route:

- Auth: `/auth/github`, `/auth/callback`, `/auth/logout`, `/auth/me`
- API tokens: `POST /tokens`, `GET /tokens`, `DELETE /tokens/:id`
- Config: `GET /config`, `PUT /config`
- Profile flow: `GET /preview-readme`, `GET /apply-readme`, `GET /apply-all`
- Repo flow: `GET /repos`, `GET /repo-scan`, `GET /repository-readme`, `GET /repo-apply`
- SVG/data (public, rate-limited): `/account-summary`, `/account-summary-md`, `/developer-rating`, `/developer-rating-insights`, `/tech-summary`, `/tech-list`, `/tech-chart`, `/tech-spider`, `/tech-categories`, `/improve-topics`, `/improve-descriptions`, `/contribution-graph`, `/stats-card`, `/monkeytype`, `/wakatime`
- Connect: `POST /monkeytype/connect|disconnect`, `POST /wakatime/connect|disconnect`
- Health: `GET /healthz`

**`README.md`**: removed the `/dashboard` section (no such route -- the SPA is served at `/`; added an explicit note), added the API-token, config, profile-flow, account-component (`/contribution-graph`, `/stats-card`), WakaTime, and `/healthz` endpoint docs, added the auth + rate-limit note to the Endpoints intro, and fixed example/local-server URLs to the actual default port `8088` (kept the `BASE_URL` env default `http://localhost:8080`, which matches the code default).

### Stale / corrected
- **`/dashboard` drift** -- removed from both README and docs/api.md; documented that the single-page UI is at `/`.
- **Duplicate/incorrect `/account-summary-md`** trailing block in docs/api.md (it described a repo score-report with `owner`/`repo` params) removed.
- **Local port** corrected `8080` -> `8088` in run/example URLs.
- The README opt-in-tiles table no longer implies `/language-trend` and `/social-links` are endpoints (they are apply-time renderers, not registered routes).

## #57 -- dev.to.md synced

- Migrated the daily-cron flow from the deprecated session-cookie path (`Cookie: session=...` / `PRETTY_README_SESSION`) to minted API tokens (`Authorization: Bearer ${{ secrets.PRETTY_README_TOKEN }}`); refreshed the secrets table and the "mint a token via `POST /tokens`" steps; removed the obsolete "a future version will support a long-lived API token" caveat.
- Added embed examples for `/contribution-graph`, `/stats-card`, `/wakatime`, extended the intro feature bullets (account tiles, Monkeytype/WakaTime), and added a rate-limiting note. Now matches README / docs/api.md.

## Intentionally deferred to the #72 Phase-5 docs pass
- `/active-languages` (#65) and `/activity-clock` (#67) -- being built in parallel, not yet on develop, so not documented here.

## Verification
- `npm run lint` -- 0 errors (6 pre-existing warnings in untouched source files).
- `npm test` -- 382/383 pass. The one failure (`smoke.test.js` "every route in the manifest is mounted") is a pre-existing environment timeout: it boots the server and fetches every route, and the GitHub/Gemini-backed routes hang with no outbound network in CI/sandbox. Verified it fails identically on the pristine `origin/develop` tree with these doc changes stashed, so it is unrelated to this PR.

Closes #56, closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
