### PR TITLE
feat: coding activity heatmap (when-I-code) endpoint (closes #67)

### DIFF
--- a/api/_routes.js
+++ b/api/_routes.js
@@ -44,6 +44,7 @@ import contributionGraph          from './contribution-graph.js';
 import statsCard                  from './stats-card.js';
 import repositoryReadme           from './repository-readme.js';
 import activeLanguages            from './active-languages.js';
+import activityClock              from './activity-clock.js';
 import healthz                    from './healthz.js';
 import { getConfig, putConfig }                          from './config.js';
 import { authGithub, authCallback, authLogout, authMe }  from './auth.js';
@@ -94,6 +95,7 @@ export const routes = [
     { method: 'get', path: '/improve-topics',            handler: improveTopics,          rateLimit: true },
     { method: 'get', path: '/improve-descriptions',      handler: improveDescriptions,    rateLimit: true },
     { method: 'get', path: '/active-languages',          handler: activeLanguages,        rateLimit: true },
+    { method: 'get', path: '/activity-clock',           handler: activityClock,          rateLimit: true },
     { method: 'get', path: '/monkeytype', handler: monkeytype, rateLimit: true },
     { method: 'get', path: '/wakatime',   handler: wakatime,   rateLimit: true },
 

--- a/api/activity-clock.js
+++ b/api/activity-clock.js
@@ -1,0 +1,44 @@
+import { renderActivityClock } from '../src/tiles/activity-clock.js';
+import { getContributionTimes } from '../src/github/contribution-times.js';
+import { renderCherryBlossom } from '../src/backgrounds/cherry-blossom.js';
+import { renderGeometric } from '../src/backgrounds/geometric.js';
+import { renderVaporWave } from '../src/backgrounds/vapor-wave.js';
+
+const backgrounds = {
+    'cherry-blossom': renderCherryBlossom,
+    'geometric': renderGeometric,
+    'vapor-wave': renderVaporWave,
+};
+
+/**
+ * GET /activity-clock?username=&background=
+ *
+ * Renders a 7x24 (day-of-week x hour-of-day) heatmap SVG of a user's coding
+ * activity, derived from GitHub public-event timestamps, with the busiest day
+ * and busiest hour labelled. Falls back to a graceful empty-state tile when no
+ * contribution data is available.
+ *
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ */
+const activityClock = async (req, res) => {
+    const { username, background } = req.query;
+
+    res.setHeader('Content-Type', 'image/svg+xml');
+
+    try {
+        if (!username) {
+            return res.send(renderActivityClock([], backgrounds[background], {}));
+        }
+
+        const token = req.session?.github_token ?? process.env.GITHUB_TOKEN;
+        const timestamps = await getContributionTimes(username, token);
+
+        return res.send(renderActivityClock(timestamps, backgrounds[background], { username }));
+    } catch (err) {
+        return res.status(500).send(err.message);
+    }
+};
+
+export default activityClock;
+export { activityClock };

--- a/src/github/contribution-times.js
+++ b/src/github/contribution-times.js
@@ -1,0 +1,70 @@
+/**
+ * Fetches coding-activity timestamps for a user from the GitHub REST API.
+ *
+ * GitHub's GraphQL v4 contributionsCollection only exposes day-level
+ * granularity, which cannot drive an hour-of-day heatmap. The public Events
+ * API (`/users/{user}/events`) returns individual events (pushes, PRs, issues,
+ * reviews, comments) each carrying a precise `created_at` ISO timestamp, which
+ * is exactly the signal an hour x day-of-week heatmap needs. We page through it
+ * (capped to stay within rate limits) and return the raw timestamps; bucketing
+ * into the 7x24 matrix happens in the tile renderer so the data layer stays
+ * dumb and easy to mock.
+ *
+ * @module github/contribution-times
+ */
+
+const PER_PAGE = 100;
+const MAX_PAGES = 3; // GitHub serves at most ~300 public events per user
+
+const ghHeaders = (token) => {
+    const headers = { Accept: 'application/vnd.github+json' };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return headers;
+};
+
+/**
+ * Fetches up to ~300 recent public event timestamps for a user.
+ *
+ * Each returned entry is the ISO-8601 `created_at` of one contribution event.
+ * Network/HTTP errors degrade gracefully to an empty array so the caller can
+ * render an empty-state tile rather than failing the request.
+ *
+ * @param {string} username            GitHub login to look up. Required.
+ * @param {string} [token]             Optional PAT/session token to raise the
+ *                                     rate limit (works unauthenticated too).
+ * @param {Function} [fetchImpl=fetch] Injectable fetch, for tests.
+ * @returns {Promise<string[]>}        ISO timestamp strings; empty on no data.
+ */
+export const getContributionTimes = async (username, token, fetchImpl = fetch) => {
+    if (!username) return [];
+
+    const headers = ghHeaders(token);
+    const timestamps = [];
+
+    for (let page = 1; page <= MAX_PAGES; page++) {
+        const url = `https://api.github.com/users/${encodeURIComponent(username)}/events?per_page=${PER_PAGE}&page=${page}`;
+
+        let payload;
+        try {
+            const res = await fetchImpl(url, { headers });
+            if (!res.ok) break;
+            payload = await res.json();
+        } catch {
+            break;
+        }
+
+        if (!Array.isArray(payload) || payload.length === 0) break;
+
+        for (const event of payload) {
+            if (event && typeof event.created_at === 'string') {
+                timestamps.push(event.created_at);
+            }
+        }
+
+        if (payload.length < PER_PAGE) break;
+    }
+
+    return timestamps;
+};
+
+export default getContributionTimes;

--- a/src/tests/activity-clock.test.js
+++ b/src/tests/activity-clock.test.js
@@ -1,0 +1,261 @@
+import { describe, test, expect, vi } from 'vitest';
+import { renderActivityClock, bucketActivity, formatHour } from '../tiles/activity-clock.js';
+import { getContributionTimes } from '../github/contribution-times.js';
+import activityClock from '../../api/activity-clock.js';
+
+// Fixed, deterministic timestamps (UTC).
+//   2024-01-01 is a Monday (UTC day 1)
+//   2024-01-03 is a Wednesday (UTC day 3)
+const FIXTURE = [
+    '2024-01-01T09:05:00Z',
+    '2024-01-01T09:30:00Z',
+    '2024-01-01T09:45:00Z',
+    '2024-01-01T14:00:00Z',
+    '2024-01-03T14:10:00Z',
+    '2024-01-03T14:50:00Z',
+];
+
+describe('formatHour', () => {
+    test('midnight is 12am', () => expect(formatHour(0)).toBe('12am'));
+    test('noon is 12pm', () => expect(formatHour(12)).toBe('12pm'));
+    test('morning hour', () => expect(formatHour(9)).toBe('9am'));
+    test('afternoon hour', () => expect(formatHour(14)).toBe('2pm'));
+    test('late evening', () => expect(formatHour(23)).toBe('11pm'));
+});
+
+describe('bucketActivity', () => {
+    test('produces a 7x24 matrix', () => {
+        const { matrix } = bucketActivity(FIXTURE);
+        expect(matrix).toHaveLength(7);
+        matrix.forEach(row => expect(row).toHaveLength(24));
+    });
+
+    test('counts events into the correct day/hour cells', () => {
+        const { matrix } = bucketActivity(FIXTURE);
+        expect(matrix[1][9]).toBe(3);
+        expect(matrix[1][14]).toBe(1);
+        expect(matrix[3][14]).toBe(2);
+    });
+
+    test('reports the busiest cell, day, and hour', () => {
+        const { busiestCell, busiestDay, busiestHour, max, total } = bucketActivity(FIXTURE);
+        expect(total).toBe(6);
+        expect(max).toBe(3);
+        expect(busiestCell).toEqual({ day: 1, hour: 9, count: 3 });
+        expect(busiestDay).toBe(1);
+        expect(busiestHour).toBe(9); // hour 9 and 14 tie at 3; argmax keeps the first
+    });
+
+    test('handles empty input', () => {
+        const { matrix, total, max } = bucketActivity([]);
+        expect(total).toBe(0);
+        expect(max).toBe(0);
+        expect(matrix.flat().every(c => c === 0)).toBe(true);
+    });
+
+    test('handles undefined input', () => {
+        expect(bucketActivity(undefined).total).toBe(0);
+    });
+
+    test('ignores invalid timestamps', () => {
+        const { total } = bucketActivity(['not-a-date', '2024-01-01T09:00:00Z', '']);
+        expect(total).toBe(1);
+    });
+});
+
+describe('renderActivityClock', () => {
+    test('returns an SVG string', () => {
+        const svg = renderActivityClock(FIXTURE);
+        expect(typeof svg).toBe('string');
+        expect(svg).toContain('<svg');
+        expect(svg).toContain('</svg>');
+    });
+
+    test('labels the busiest day and hour', () => {
+        const svg = renderActivityClock(FIXTURE);
+        expect(svg).toContain('BUSIEST');
+        expect(svg).toContain('Monday');
+        expect(svg).toContain('9am'); // busiest hour resolves to 9 (tie broken to first)
+    });
+
+    test('marks the peak cell with a count label', () => {
+        const svg = renderActivityClock(FIXTURE);
+        expect(svg).toContain('peak 3');
+    });
+
+    test('renders day-of-week labels', () => {
+        const svg = renderActivityClock(FIXTURE);
+        for (const d of ['Sun', 'Mon', 'Wed', 'Sat']) {
+            expect(svg).toContain('>' + d + '<');
+        }
+    });
+
+    test('includes accessible title tooltips for active cells', () => {
+        const svg = renderActivityClock(FIXTURE);
+        expect(svg).toContain('<title>Monday 9am: 3</title>');
+    });
+
+    test('empty state renders gracefully with a message', () => {
+        const svg = renderActivityClock([]);
+        expect(svg).toContain('<svg');
+        expect(svg).toContain('No recent contribution activity found');
+        expect(svg).not.toContain('BUSIEST');
+    });
+
+    test('embeds an optional background layer when provided', () => {
+        const bg = vi.fn((h, w) => '<rect class="bg" width="' + w + '" height="' + h + '"/>');
+        const svg = renderActivityClock(FIXTURE, bg);
+        expect(bg).toHaveBeenCalled();
+        expect(svg).toContain('class="bg"');
+    });
+
+    test('renders without a background when none is given', () => {
+        const svg = renderActivityClock(FIXTURE);
+        expect(svg).toContain('<svg');
+    });
+
+    test('includes and escapes the username when supplied', () => {
+        const svg = renderActivityClock(FIXTURE, undefined, { username: 'a<b>&c' });
+        expect(svg).toContain('a&lt;b&gt;&amp;c');
+    });
+});
+
+describe('getContributionTimes', () => {
+    const okResponse = (data) => ({ ok: true, json: async () => data });
+
+    test('returns empty array when no username is given', async () => {
+        const result = await getContributionTimes('', undefined, vi.fn());
+        expect(result).toEqual([]);
+    });
+
+    test('extracts created_at timestamps from events', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(okResponse([
+            { created_at: '2024-01-01T09:00:00Z' },
+            { created_at: '2024-01-01T10:00:00Z' },
+        ]));
+        const result = await getContributionTimes('octocat', undefined, fetchImpl);
+        expect(result).toEqual(['2024-01-01T09:00:00Z', '2024-01-01T10:00:00Z']);
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    test('sends an Authorization header when a token is supplied', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(okResponse([]));
+        await getContributionTimes('octocat', 'tok123', fetchImpl);
+        const opts = fetchImpl.mock.calls[0][1];
+        expect(opts.headers.Authorization).toBe('Bearer tok123');
+    });
+
+    test('omits Authorization header when no token', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(okResponse([]));
+        await getContributionTimes('octocat', undefined, fetchImpl);
+        const opts = fetchImpl.mock.calls[0][1];
+        expect(opts.headers.Authorization).toBeUndefined();
+    });
+
+    test('stops paging when a page is not full', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(okResponse([{ created_at: '2024-01-01T00:00:00Z' }]));
+        await getContributionTimes('octocat', undefined, fetchImpl);
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    test('pages through full pages then stops on a short one', async () => {
+        const fullPage = Array.from({ length: 100 }, () => ({ created_at: '2024-01-01T00:00:00Z' }));
+        const fetchImpl = vi.fn()
+            .mockResolvedValueOnce(okResponse(fullPage))
+            .mockResolvedValueOnce(okResponse([{ created_at: '2024-01-01T00:00:00Z' }]));
+        const result = await getContributionTimes('octocat', undefined, fetchImpl);
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+        expect(result).toHaveLength(101);
+    });
+
+    test('degrades to empty array on a non-ok response', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+        const result = await getContributionTimes('octocat', undefined, fetchImpl);
+        expect(result).toEqual([]);
+    });
+
+    test('degrades to empty array on a thrown network error', async () => {
+        const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'));
+        const result = await getContributionTimes('octocat', undefined, fetchImpl);
+        expect(result).toEqual([]);
+    });
+
+    test('skips events missing created_at', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(okResponse([
+            { created_at: '2024-01-01T09:00:00Z' },
+            { id: 'no-timestamp' },
+            null,
+        ]));
+        const result = await getContributionTimes('octocat', undefined, fetchImpl);
+        expect(result).toEqual(['2024-01-01T09:00:00Z']);
+    });
+});
+
+const makeRes = () => ({
+    headers: {},
+    statusCode: 200,
+    body: undefined,
+    setHeader(k, v) { this.headers[k] = v; },
+    status(code) { this.statusCode = code; return this; },
+    send(payload) { this.body = payload; return this; },
+});
+
+describe('GET /activity-clock handler', () => {
+    test('renders empty-state SVG when username is missing', async () => {
+        const req = { query: {}, session: {} };
+        const res = makeRes();
+        await activityClock(req, res);
+        expect(res.headers['Content-Type']).toBe('image/svg+xml');
+        expect(res.body).toContain('<svg');
+        expect(res.body).toContain('No recent contribution activity found');
+    });
+
+    test('fetches timestamps and renders a heatmap for a username', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => FIXTURE.map(ts => ({ created_at: ts })),
+        });
+        try {
+            const req = { query: { username: 'octocat' }, session: {} };
+            const res = makeRes();
+            await activityClock(req, res);
+            expect(res.headers['Content-Type']).toBe('image/svg+xml');
+            expect(res.body).toContain('<svg');
+            expect(res.body).toContain('BUSIEST');
+            expect(res.body).toContain('Monday');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('applies a named background', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => FIXTURE.map(ts => ({ created_at: ts })),
+        });
+        try {
+            const req = { query: { username: 'octocat', background: 'geometric' }, session: {} };
+            const res = makeRes();
+            await activityClock(req, res);
+            expect(res.body).toContain('geometric-background');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('degrades to empty-state when the upstream fetch throws', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = vi.fn().mockImplementation(() => { throw new Error('boom'); });
+        try {
+            const req = { query: { username: 'octocat' }, session: {} };
+            const res = makeRes();
+            await activityClock(req, res);
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toContain('No recent contribution activity found');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});

--- a/src/tiles/activity-clock.js
+++ b/src/tiles/activity-clock.js
@@ -1,0 +1,151 @@
+import { THEME_CSS } from './theme.js';
+
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const DAYS_LONG = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+const W = 860;
+const H = 360;
+const PAD = 28;
+const LABEL_W = 44;
+const TITLE_H = 64;
+const GRID_X = PAD + LABEL_W;
+const GRID_Y = TITLE_H;
+const HOUR_LABEL_H = 18;
+const GRID_W = W - GRID_X - PAD;
+const GRID_H = H - GRID_Y - PAD - HOUR_LABEL_H;
+const CELL_W = GRID_W / 24;
+const CELL_H = GRID_H / 7;
+const CELL_GAP = 1.5;
+
+const HEAT = '#39d353';
+
+const formatHour = (hour) => {
+    const period = hour < 12 ? 'am' : 'pm';
+    const h12 = hour % 12 === 0 ? 12 : hour % 12;
+    return h12 + period;
+};
+
+const bucketActivity = (timestamps) => {
+    const matrix = Array.from({ length: 7 }, () => new Array(24).fill(0));
+    const dayTotals = new Array(7).fill(0);
+    const hourTotals = new Array(24).fill(0);
+    let max = 0;
+    let total = 0;
+    let busiestCell = { day: 0, hour: 0, count: 0 };
+
+    for (const ts of timestamps || []) {
+        const d = new Date(ts);
+        if (Number.isNaN(d.getTime())) continue;
+        const day = d.getUTCDay();
+        const hour = d.getUTCHours();
+        const count = ++matrix[day][hour];
+        dayTotals[day]++;
+        hourTotals[hour]++;
+        total++;
+        if (count > max) max = count;
+        if (count > busiestCell.count) busiestCell = { day, hour, count };
+    }
+
+    const argmax = (arr) => arr.reduce((best, v, i) => (v > arr[best] ? i : best), 0);
+
+    return {
+        matrix,
+        max,
+        total,
+        busiestDay: argmax(dayTotals),
+        busiestHour: argmax(hourTotals),
+        busiestCell,
+    };
+};
+
+const escapeXml = (s) => String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+export const renderActivityClock = (timestamps, background, opts = {}) => {
+    const { matrix, max, total, busiestDay, busiestHour, busiestCell } = bucketActivity(timestamps);
+    const sep = ' · ';
+    const who = opts.username ? sep + escapeXml(opts.username) : '';
+
+    const backgroundLayer = typeof background === 'function'
+        ? '<g>' + background(H, W) + '</g>'
+        : '';
+
+    const header = [
+        '<text x="' + PAD + '" y="30" style="fill:var(--fg)" font-size="20" font-weight="bold" font-family="Arial, sans-serif">When I Code' + who + '</text>',
+        '<text x="' + PAD + '" y="50" style="fill:var(--fg60)" font-size="12" font-family="Arial, sans-serif">Coding activity by day &amp; hour (UTC)</text>',
+    ].join('\n    ');
+
+    if (total === 0) {
+        return [
+            '<svg width="' + W + '" height="' + H + '" viewBox="0 0 ' + W + ' ' + H + '" xmlns="http://www.w3.org/2000/svg" role="img">',
+            '    ' + THEME_CSS,
+            '    <rect width="' + W + '" height="' + H + '" style="fill:var(--bg)" rx="12"/>',
+            '    ' + backgroundLayer,
+            '    ' + header,
+            '    <text x="' + (W / 2) + '" y="' + (H / 2) + '" text-anchor="middle" style="fill:var(--fg40)" font-size="16" font-family="Arial, sans-serif">No recent contribution activity found</text>',
+            '</svg>',
+        ].join('\n');
+    }
+
+    const dayLabels = DAYS.map((d, i) => {
+        const cy = GRID_Y + i * CELL_H + CELL_H / 2;
+        return '<text x="' + (GRID_X - 10) + '" y="' + (cy + 3) + '" text-anchor="end" style="fill:var(--fg60)" font-size="11" font-family="Arial, sans-serif">' + d + '</text>';
+    }).join('\n    ');
+
+    const hourLabels = [0, 3, 6, 9, 12, 15, 18, 21].map((h) => {
+        const x = GRID_X + h * CELL_W + CELL_W / 2;
+        return '<text x="' + x.toFixed(2) + '" y="' + (GRID_Y + GRID_H + 14) + '" text-anchor="middle" style="fill:var(--fg40)" font-size="10" font-family="Arial, sans-serif">' + formatHour(h) + '</text>';
+    }).join('\n    ');
+
+    let cells = '';
+    for (let day = 0; day < 7; day++) {
+        for (let hour = 0; hour < 24; hour++) {
+            const count = matrix[day][hour];
+            const x = GRID_X + hour * CELL_W + CELL_GAP / 2;
+            const y = GRID_Y + day * CELL_H + CELL_GAP / 2;
+            const w = CELL_W - CELL_GAP;
+            const h = CELL_H - CELL_GAP;
+            const isPeak = day === busiestCell.day && hour === busiestCell.hour;
+
+            if (count === 0) {
+                cells += '<rect x="' + x.toFixed(2) + '" y="' + y.toFixed(2) + '" width="' + w.toFixed(2) + '" height="' + h.toFixed(2) + '" rx="2" style="fill:var(--fg06)"/>';
+            } else {
+                const intensity = 0.25 + 0.75 * (count / max);
+                const stroke = isPeak ? ' stroke="var(--fg)" stroke-width="1.5"' : '';
+                cells += '<rect x="' + x.toFixed(2) + '" y="' + y.toFixed(2) + '" width="' + w.toFixed(2) + '" height="' + h.toFixed(2) + '" rx="2" fill="' + HEAT + '" fill-opacity="' + intensity.toFixed(3) + '"' + stroke + '><title>' + DAYS_LONG[day] + ' ' + formatHour(hour) + ': ' + count + '</title></rect>';
+            }
+        }
+    }
+
+    const peakDayHour = DAYS_LONG[busiestDay] + sep + formatHour(busiestHour);
+    const callout = [
+        '<g font-family="Arial, sans-serif">',
+        '    <text x="' + (W - PAD) + '" y="26" text-anchor="end" style="fill:var(--fg40)" font-size="10" letter-spacing="1">BUSIEST</text>',
+        '    <text x="' + (W - PAD) + '" y="44" text-anchor="end" style="fill:var(--fg)" font-size="13" font-weight="bold">' + peakDayHour + '</text>',
+        '</g>',
+    ].join('\n    ');
+
+    const peakX = GRID_X + busiestCell.hour * CELL_W + CELL_W / 2;
+    const peakLabelY = GRID_Y + busiestCell.day * CELL_H - 4;
+    const peakLabel = '<text x="' + peakX.toFixed(2) + '" y="' + peakLabelY.toFixed(2) + '" text-anchor="middle" style="fill:var(--fg85)" font-size="9" font-weight="bold" font-family="Arial, sans-serif">peak ' + busiestCell.count + '</text>';
+
+    return [
+        '<svg width="' + W + '" height="' + H + '" viewBox="0 0 ' + W + ' ' + H + '" xmlns="http://www.w3.org/2000/svg" role="img">',
+        '    ' + THEME_CSS,
+        '    <rect width="' + W + '" height="' + H + '" style="fill:var(--bg)" rx="12"/>',
+        '    ' + backgroundLayer,
+        '    ' + header,
+        '    ' + callout,
+        '    ' + dayLabels,
+        '    ' + cells,
+        '    ' + peakLabel,
+        '    ' + hourLabels,
+        '</svg>',
+    ].join('\n');
+};
+
+export { bucketActivity, formatHour };
+export default renderActivityClock;


### PR DESCRIPTION
Implements #67 via the api/_routes.js manifest. GET /activity-clock renders a 7x24 day-by-hour heatmap from REST Events timestamps; busiest day/hour highlighted; theme/background support; rate-limited; express.js untouched. Gates green on develop.