### PR TITLE
feat: opt-in Phase 5 tiles in profile preview/apply (closes #70)

### DIFF
--- a/api/apply-readme.js
+++ b/api/apply-readme.js
@@ -12,6 +12,15 @@ import { renderLanguageTrend }              from '../src/tiles/language-trend.js
 import { renderSocialLinks }                from '../src/tiles/social-links.js';
 import { buildDataset as buildLanguageTrendDataset } from './language-trend.js';
 import { badgesFromConfig as buildSocialBadges }     from './social-links.js';
+import { renderActiveLanguages }            from '../src/tiles/active-languages.js';
+import { renderTopRepos }                   from '../src/tiles/top-repos.js';
+import { renderActivityClock }              from '../src/tiles/activity-clock.js';
+import { renderWakatimeChart }              from '../src/tiles/wakatime-chart.js';
+import { getRecentLanguageWeights }         from '../src/github/recent-languages.js';
+import { getContributionTimes }             from '../src/github/contribution-times.js';
+import { getTimeByLanguage, createWakatimeClient } from '../src/wakatime/client.js';
+import { selectRepos }                      from './top-repos.js';
+import { toCardData }                       from './repo-card.js';
 import { readConfig, resolveEnabledTiles }  from '../src/github/config.js';
 import { GoogleGenerativeAI }              from '@google/generative-ai';
 import { previewCache }                    from '../src/preview-cache.js';
@@ -413,6 +422,11 @@ const renderInsights = (rating, insights, repos, recommendations = '') => {
 const LANGUAGE_TREND_REPO_CAP = 40;
 const LANGUAGE_TREND_LANG_LIMIT = 6;
 
+// Defaults mirror the Phase 5 endpoints (/active-languages, /top-repos, /wakatime).
+const ACTIVE_LANGUAGES_DAYS = 90;   // matches /active-languages default window
+const TOP_REPOS_LIMIT       = 6;    // matches /top-repos DEFAULT_LIMIT
+const WAKATIME_RANGE        = 'last_7_days'; // matches /wakatime default range
+
 /**
  * Builders for the opt-in account tiles, keyed by the canonical tile id used in
  * `.pretty-readme.json`. Each builder receives a context `{ token, username,
@@ -429,6 +443,21 @@ const ACCOUNT_TILE_BUILDERS = {
         renderLanguageTrend(await buildLanguageTrendDataset(repos, token, LANGUAGE_TREND_REPO_CAP, LANGUAGE_TREND_LANG_LIMIT)),
     socialLinks: async ({ config }) =>
         renderSocialLinks(buildSocialBadges(config?.social)),
+    activeLanguages: async ({ token, username }) =>
+        renderActiveLanguages(
+            (await getRecentLanguageWeights(username, { days: ACTIVE_LANGUAGES_DAYS, token }))
+                ?? { langs: [], totalCommits: 0, days: ACTIVE_LANGUAGES_DAYS },
+        ),
+    topRepos: async ({ repos }) =>
+        renderTopRepos(selectRepos(repos, { limit: TOP_REPOS_LIMIT }).map(toCardData)),
+    activityClock: async ({ token, username }) =>
+        renderActivityClock(await getContributionTimes(username, token), undefined, { username }),
+    wakatime: async ({ wakatimeKey }) => {
+        if (!wakatimeKey) throw new Error('WakaTime not connected');
+        const languages = await getTimeByLanguage(WAKATIME_RANGE, createWakatimeClient({ apiKey: wakatimeKey }));
+        if (!languages || languages.length === 0) throw new Error('no WakaTime language data');
+        return renderWakatimeChart(languages, { range: WAKATIME_RANGE });
+    },
 };
 
 /** Asset path + alt text per tile, used when injecting into the profile README. */
@@ -437,6 +466,10 @@ const ACCOUNT_TILE_ASSETS = {
     statsCard:         { asset: 'assets/stats-card.svg',         alt: 'GitHub Stats',       marker: 'stats' },
     languageTrend:     { asset: 'assets/language-trend.svg',     alt: 'Language Trend',     marker: 'language-trend' },
     socialLinks:       { asset: 'assets/social-links.svg',       alt: 'Social Links',       marker: 'social-links' },
+    activeLanguages:   { asset: 'assets/active-languages.svg',   alt: 'Active Languages',   marker: 'active-languages' },
+    topRepos:          { asset: 'assets/top-repos.svg',          alt: 'Top Repositories',   marker: 'top-repos' },
+    activityClock:     { asset: 'assets/activity-clock.svg',     alt: 'Activity Clock',     marker: 'activity-clock' },
+    wakatime:          { asset: 'assets/wakatime.svg',           alt: 'WakaTime',           marker: 'wakatime' },
 };
 
 /**
@@ -478,7 +511,7 @@ export async function buildAccountTiles(ctx, log = () => {}) {
 
 // ── Core profile generator ────────────────────────────────────────────────────
 
-export async function generateProfile(token, username, monkeyOptions = {}, onProgress = null) {
+export async function generateProfile(token, username, monkeyOptions = {}, onProgress = null, extraOptions = {}) {
     const steps = [];
     const emit  = (pct, msg) => { onProgress?.({ pct, msg }); };
     const log   = (msg) => { steps.push(msg); console.log(`[apply-readme] ${msg}`); };
@@ -560,7 +593,7 @@ export async function generateProfile(token, username, monkeyOptions = {}, onPro
 
     emit(64, 'Rendering account tiles…');
     log('Rendering opt-in account tiles…');
-    const accountTiles = await buildAccountTiles({ token, username, repos }, log);
+    const accountTiles = await buildAccountTiles({ token, username, repos, wakatimeKey: extraOptions.wakatimeKey ?? null }, log);
     if (Object.keys(accountTiles).length) log(`Enabled account tiles: ${Object.keys(accountTiles).join(', ')}`);
 
     emit(68, 'Generating recommendations…');
@@ -613,13 +646,16 @@ export default async (req, res) => {
             apiKey:   req.session?.monkeytype_key ?? process.env.MONKEYTYPE_API_KEY ?? null,
             username: req.session?.monkeytype_username ?? process.env.MONKEYTYPE_USERNAME ?? null,
         };
+        const extraOptions = {
+            wakatimeKey: req.session?.wakatime_key ?? process.env.WAKATIME_API_KEY ?? null,
+        };
 
         const onProgress = send ? ({ pct, msg }) => send({ type: 'progress', pct, msg }) : null;
 
         // Reuse cached preview if available so we don't regenerate on every apply
         const cachedProfile = previewCache.get(username);
         if (cachedProfile) send?.({ type: 'progress', pct: 80, msg: 'Using cached profile data…' });
-        const profile = cachedProfile ?? await generateProfile(token, username, monkeyOptions, onProgress);
+        const profile = cachedProfile ?? await generateProfile(token, username, monkeyOptions, onProgress, extraOptions);
         if (!cachedProfile) previewCache.set(username, profile);
 
         if (dryRun) {
@@ -643,6 +679,10 @@ export default async (req, res) => {
             { key: 'stats',     start: '<!-- stats-start -->',        end: '<!-- stats-end -->',   optional: true, enabled: () => !!profile.accountTiles?.statsCard },
             { key: 'language',  start: '<!-- language-trend-start -->', end: '<!-- language-trend-end -->', optional: true, enabled: () => !!profile.accountTiles?.languageTrend },
             { key: 'social',    start: '<!-- social-links-start -->', end: '<!-- social-links-end -->', optional: true, enabled: () => !!profile.accountTiles?.socialLinks },
+            { key: 'active-languages', start: '<!-- active-languages-start -->', end: '<!-- active-languages-end -->', optional: true, enabled: () => !!profile.accountTiles?.activeLanguages },
+            { key: 'top-repos', start: '<!-- top-repos-start -->',     end: '<!-- top-repos-end -->',     optional: true, enabled: () => !!profile.accountTiles?.topRepos },
+            { key: 'activity-clock', start: '<!-- activity-clock-start -->', end: '<!-- activity-clock-end -->', optional: true, enabled: () => !!profile.accountTiles?.activityClock },
+            { key: 'wakatime-tile', start: '<!-- wakatime-start -->',   end: '<!-- wakatime-end -->',   optional: true, enabled: () => !!profile.accountTiles?.wakatime },
             { key: 'monkeytype',start: '<!-- monkeytype-start -->',   end: '<!-- monkeytype-end -->', optional: true, enabled: () => !!profile.monkeytypeSvg },
             { key: 'charts',    start: '<!-- tech-charts-start -->',   end: '<!-- tech-charts-end -->' },
             { key: 'badges',    start: '<!-- tech-start -->',          end: '<!-- tech-end -->' },

--- a/api/preview-readme.js
+++ b/api/preview-readme.js
@@ -39,7 +39,10 @@ export default async (req, res) => {
             apiKey:   req.session.monkeytype_key   ?? null,
             username: req.session.monkeytype_username ?? null,
         };
-        const profile = await generateProfile(token, username, monkeyOptions);
+        const extraOptions = {
+            wakatimeKey: req.session.wakatime_key ?? process.env.WAKATIME_API_KEY ?? null,
+        };
+        const profile = await generateProfile(token, username, monkeyOptions, null, extraOptions);
         previewCache.set(username, profile);
         return res.json({
             ok:            true,

--- a/src/github/config.js
+++ b/src/github/config.js
@@ -16,7 +16,16 @@ const CONFIG_PATH = '.pretty-readme.json';
  * config file) renders exactly as before. Keys are the canonical tile ids
  * shared across the preview and apply flows.
  */
-export const ACCOUNT_TILES = ['contributionGraph', 'statsCard', 'languageTrend', 'socialLinks'];
+export const ACCOUNT_TILES = [
+    'contributionGraph',
+    'statsCard',
+    'languageTrend',
+    'socialLinks',
+    'activeLanguages',
+    'topRepos',
+    'activityClock',
+    'wakatime',
+];
 
 /**
  * Resolve which optional account tiles are enabled for a given config object.

--- a/src/tests/build-account-tiles.test.js
+++ b/src/tests/build-account-tiles.test.js
@@ -13,11 +13,17 @@ vi.mock('../github/graphql.js', () => ({
 }));
 vi.mock('../../api/language-trend.js', () => ({ buildDataset: vi.fn() }));
 vi.mock('../../api/social-links.js', () => ({ badgesFromConfig: vi.fn() }));
+vi.mock('../github/recent-languages.js', () => ({ getRecentLanguageWeights: vi.fn() }));
+vi.mock('../github/contribution-times.js', () => ({ getContributionTimes: vi.fn() }));
+vi.mock('../wakatime/client.js', () => ({ getTimeByLanguage: vi.fn(), createWakatimeClient: vi.fn(() => ({})) }));
 
 import { readConfig, resolveEnabledTiles } from '../github/config.js';
 import { getContributionCalendar, getUserStats } from '../github/graphql.js';
 import { buildDataset } from '../../api/language-trend.js';
 import { badgesFromConfig } from '../../api/social-links.js';
+import { getRecentLanguageWeights } from '../github/recent-languages.js';
+import { getContributionTimes } from '../github/contribution-times.js';
+import { getTimeByLanguage } from '../wakatime/client.js';
 import { buildAccountTiles } from '../../api/apply-readme.js';
 
 const calendar = { totalContributions: 1, weeks: [{ contributionDays: [{ weekday: 0, contributionCount: 1, color: '#39d353' }] }] };
@@ -80,5 +86,48 @@ describe('buildAccountTiles', () => {
         readConfig.mockRejectedValue(new Error('config 500'));
         const tiles = await buildAccountTiles(ctx());
         expect(tiles).toEqual({});
+    });
+});
+
+describe('buildAccountTiles — Phase 5 opt-in tiles (#70)', () => {
+    test('renders the four Phase 5 tiles when enabled', async () => {
+        resolveEnabledTiles.mockReturnValue(['activeLanguages', 'topRepos', 'activityClock', 'wakatime']);
+        getRecentLanguageWeights.mockResolvedValue({ langs: [{ language: 'JavaScript', count: 5 }], totalCommits: 5, days: 90 });
+        getContributionTimes.mockResolvedValue([new Date('2024-01-01T10:00:00Z').toISOString()]);
+        getTimeByLanguage.mockResolvedValue([{ name: 'JavaScript', total_seconds: 3600, percent: 100 }]);
+
+        const repos = [{ name: 'r', owner: { login: 'kev' }, stargazers_count: 9, fork: false, language: 'JavaScript' }];
+        const tiles = await buildAccountTiles(ctx({ repos, wakatimeKey: 'waka-key' }));
+
+        expect(Object.keys(tiles).sort()).toEqual(['activeLanguages', 'activityClock', 'topRepos', 'wakatime']);
+        expect(tiles.activeLanguages).toContain('<svg');
+        expect(tiles.topRepos).toContain('<svg');
+        expect(tiles.activityClock).toContain('<svg');
+        expect(tiles.wakatime).toContain('<svg');
+        // active-languages reuses the recent-language weighting with the apply default window
+        expect(getRecentLanguageWeights).toHaveBeenCalledWith('kev', { days: 90, token: 'tok' });
+    });
+
+    test('Phase 5 tiles are absent when their flag is off (opt-in)', async () => {
+        resolveEnabledTiles.mockReturnValue([]);
+        const tiles = await buildAccountTiles(ctx({ wakatimeKey: 'waka-key' }));
+        expect(tiles).toEqual({});
+        expect(getRecentLanguageWeights).not.toHaveBeenCalled();
+        expect(getContributionTimes).not.toHaveBeenCalled();
+        expect(getTimeByLanguage).not.toHaveBeenCalled();
+    });
+
+    test('wakatime tile is skipped (not fatal) when no key is connected', async () => {
+        resolveEnabledTiles.mockReturnValue(['wakatime']);
+        const tiles = await buildAccountTiles(ctx({ wakatimeKey: null }));
+        expect(tiles).toEqual({});
+        expect(getTimeByLanguage).not.toHaveBeenCalled();
+    });
+
+    test('active-languages falls back to an empty tile when weighting returns null', async () => {
+        resolveEnabledTiles.mockReturnValue(['activeLanguages']);
+        getRecentLanguageWeights.mockResolvedValue(null);
+        const tiles = await buildAccountTiles(ctx());
+        expect(tiles.activeLanguages).toContain('<svg');
     });
 });

--- a/src/tests/config-tiles.test.js
+++ b/src/tests/config-tiles.test.js
@@ -28,4 +28,15 @@ describe('resolveEnabledTiles', () => {
         const allOn = { tiles: Object.fromEntries(ACCOUNT_TILES.map((k) => [k, true])) };
         expect(resolveEnabledTiles(allOn)).toEqual(ACCOUNT_TILES);
     });
+
+    test('the four Phase 5 tiles (#70) are advertised and opt-in', () => {
+        const phase5 = ['activeLanguages', 'topRepos', 'activityClock', 'wakatime'];
+        // each is a recognised tile id
+        phase5.forEach((id) => expect(ACCOUNT_TILES).toContain(id));
+        // off by default — absent from a config with no tiles block
+        phase5.forEach((id) => expect(resolveEnabledTiles({})).not.toContain(id));
+        // enabled only when set to true
+        const config = { tiles: { activeLanguages: true, topRepos: true, activityClock: true, wakatime: true } };
+        expect(resolveEnabledTiles(config)).toEqual(phase5);
+    });
 });


### PR DESCRIPTION
Implements #70. Adds active-languages, top-repos, activity-clock, and wakatime as opt-in tiles in the profile preview/apply flow, toggled via .pretty-readme.json (all default OFF), consistent with the existing #42 accountTiles pattern. Dry-run preview reflects enabled tiles. Gates green on develop.