### PR TITLE
docs: document Phase 5 + newly-mounted endpoints, opt-in tiles (closes #72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,39 @@ Uses AI to suggest and apply descriptions to owned GitHub repositories that curr
 http://localhost:8088/improve-descriptions?dry_run=true
 ```
 
+#### GET /active-languages
+
+Generates an SVG tile of the languages a user has worked in **recently**, weighted by commit activity inside the window (not lifetime repo bytes). Cached for 1 hour per `(username, days)`. Always responds with an SVG — a missing user or any error renders a graceful empty tile rather than a 4xx/5xx body.
+
+**Query Parameters:**
+
+| Name         | Default | Description |
+| :----------- | :------ | :---------- |
+| `username`   |         | The GitHub login whose recent activity is charted (required; absent renders an empty tile). |
+| `days`       | `90`    | Recent window in days. Non-numeric or `<= 0` falls back to `90`; capped at `365`. |
+| `background` | `null`  | Theme: `cherry-blossom`, `geometric`, or `vapor-wave`. |
+
+**Example URL:**
+```
+http://localhost:8088/active-languages?username=octocat&days=180&background=geometric
+```
+
+#### GET /activity-clock
+
+Renders a 7×24 (day-of-week × hour-of-day) heatmap SVG of a user's coding activity, derived from GitHub public-event timestamps, with the busiest day and hour labelled. Falls back to a graceful empty tile when no data is available.
+
+**Query Parameters:**
+
+| Name         | Default | Description |
+| :----------- | :------ | :---------- |
+| `username`   |         | GitHub login (required; absent renders an empty tile). |
+| `background` | `null`  | Theme: `cherry-blossom`, `geometric`, or `vapor-wave`. |
+
+**Example URL:**
+```
+http://localhost:8088/activity-clock?username=octocat&background=vapor-wave
+```
+
 #### GET /monkeytype
 
 Generates an SVG chart visualizing Monkeytype typing speed personal bests across different time modes. Requires an active session with a connected Monkeytype API key or `MONKEYTYPE_API_KEY` set in the environment.
@@ -493,6 +526,105 @@ Generates an SVG chart of coding time by language from the WakaTime API. Resolve
 **Example URL:**
 ```
 http://localhost:8088/wakatime?range=last_30_days
+```
+
+#### GET /language-trend
+
+Approximates how a user's language usage has grown over time by bucketing each repository's language bytes by the repo's creation year and rendering a cumulative **stacked-area** chart. Reads the session GitHub token when present, else `GITHUB_TOKEN`. Cached for 15 minutes per user. `401` when no GitHub token is available.
+
+**Query Parameters:**
+
+| Name       | Default | Description |
+| :--------- | :------ | :---------- |
+| `repos`    | `40`    | Cap on the number of (largest, non-fork) repos scanned for `/languages` (min 1). |
+| `limit`    | `6`     | Max languages shown as stacked series (min 1). |
+| `username` | `env`   | Cache key when unauthenticated (the session user takes precedence when signed in). |
+
+**Example URL:**
+```
+http://localhost:8088/language-trend?repos=60&limit=8
+```
+
+#### GET /social-links
+
+Renders a row of brand badges linking to a user's social profiles. Links come (in order) from the `?links=` query param, or — when authenticated — the `social` map in the user's `.pretty-readme.json`. Unknown platforms degrade to a generic link badge.
+
+**Query Parameters:**
+
+| Name       | Default | Description |
+| :--------- | :------ | :---------- |
+| `links`    |         | Comma-separated `platform:handle` pairs, e.g. `github:octocat,email:me@example.com`. Overrides config when present. Only the first colon splits each pair, so handles may be full URLs. |
+| `username` |         | When unauthenticated and `links` is omitted, the login whose config `social` map is read (requires `GITHUB_TOKEN`). |
+
+**Example URL:**
+```
+http://localhost:8088/social-links?links=github:octocat,linkedin:octocat,email:octocat@github.com
+```
+
+#### GET /repo-tech-badges
+
+Returns a **Markdown** (plain-text) row of shields.io tech badges derived from a repo's primary language and topics. `200` with an empty body when no tech is detected; `400` for a missing/malformed `repo`; `404` when not found; `502` on an upstream error.
+
+**Query Parameters:**
+
+| Name   | Default | Description |
+| :----- | :------ | :---------- |
+| `repo` |         | **Required.** `owner/name`. |
+
+**Example URL:**
+```
+http://localhost:8088/repo-tech-badges?repo=octocat/Hello-World
+```
+
+#### GET /repo-card
+
+Renders a theme-aware SVG card for a single repo with its stars, forks, open issues, primary language, and last-updated time. `400` for a missing/malformed `repo`; `404` when not found; `502` on an upstream error.
+
+**Query Parameters:**
+
+| Name   | Default | Description |
+| :----- | :------ | :---------- |
+| `repo` |         | **Required.** `owner/name`. |
+
+**Example URL:**
+```
+http://localhost:8088/repo-card?repo=octocat/Hello-World
+```
+
+#### GET /repo-activity
+
+Renders a repository's weekly commit activity for the last year as a themed SVG bar chart. Always responds with an SVG — error and empty states render as SVG cards so the image never breaks in a README.
+
+**Query Parameters:**
+
+| Name   | Default | Description |
+| :----- | :------ | :---------- |
+| `repo` |         | **Required.** `owner/name`, or a bare `name` combined with `user=`. |
+| `user` |         | Owner login, used when `repo` is a bare name. |
+
+**Example URLs:**
+```
+http://localhost:8088/repo-activity?repo=octocat/Hello-World
+http://localhost:8088/repo-activity?user=octocat&repo=Hello-World
+```
+
+#### GET /top-repos
+
+Renders a grid of repo cards for a user's most notable repositories (reusing the repo-card renderer). Forks are excluded by default; an empty selection renders a graceful placeholder. `400` for a missing `username`; `502` on an upstream error.
+
+**Query Parameters:**
+
+| Name       | Default | Description |
+| :--------- | :------ | :---------- |
+| `username` |         | **Required.** GitHub login. |
+| `sort`     | `stars` | `stars` or `updated` (most recently pushed). |
+| `limit`    | `6`     | Number of cards (clamped to 1–12). |
+| `columns`  | `2`     | Grid columns. |
+| `forks`    | `false` | `true`/`1` includes forks. |
+
+**Example URL:**
+```
+http://localhost:8088/top-repos?username=octocat&sort=updated&limit=8&columns=3
 ```
 
 ### Health
@@ -559,8 +691,16 @@ you want to `true`:
 | :------------------ | :------ |
 | `contributionGraph` | Contribution heatmap + current/longest streak (`/contribution-graph`). |
 | `statsCard`         | Stars / commits / PRs / issues / followers / contributed-to card (`/stats-card`). |
-| `languageTrend`     | Cumulative language-usage-over-time stacked area chart (rendered at apply time; no standalone endpoint yet). |
-| `socialLinks`       | Brand badges linking to your social profiles, built from the `social` map below (rendered at apply time; no standalone endpoint yet). |
+| `languageTrend`     | Cumulative language-usage-over-time stacked area chart (`/language-trend`). |
+| `socialLinks`       | Brand badges linking to your social profiles, built from the `social` map below (`/social-links`). |
+| `activeLanguages`   | Languages worked in recently, weighted by commit activity (`/active-languages`). |
+| `topRepos`          | A grid of repo cards for your most notable repositories (`/top-repos`). |
+| `activityClock`     | A 7×24 day-by-hour heatmap of your coding activity (`/activity-clock`). |
+| `wakatime`          | Coding time by language from WakaTime — requires a connected WakaTime key (`/wakatime`). |
+
+Each tile is also a live, standalone, rate-limited GET endpoint (linked above) you
+can embed directly; the opt-in `tiles` block just renders the same output into your
+profile README at apply time.
 
 The `socialLinks` tile reads the top-level `social` map — `platform: handle`
 pairs (e.g. `github`, `twitter`/`x`, `linkedin`, `devto`, `mastodon`, `email`,

--- a/dev.to.md
+++ b/dev.to.md
@@ -9,7 +9,8 @@ Your GitHub profile README is usually a snapshot frozen in time. You set it up o
 - An **AI-written bio** — regenerated from your real commit history, not a template
 - **SCORE.md** per repo — a code quality report graded A–F across six dimensions
 - **AI topics and descriptions** for repos that are missing them
-- **Account tiles** -- an opt-in contribution heatmap (with streaks), a GitHub stats card, a language-trend chart, and social-link badges
+- **Account tiles** -- opt-in extras: a contribution heatmap (with streaks), a GitHub stats card, a language-trend chart, social-link badges, a recent-languages tile, a top-repositories grid, and a day-by-hour activity clock
+- **Repo tiles** -- a repo card, a weekly commit-activity chart, and a shields.io tech-badge row for any single repo
 - **Typing & coding stats** -- optional Monkeytype WPM and WakaTime coding-time charts
 
 Everything outputs as SVG or Markdown, embeds directly into any README, and can run on a daily cron so it's always current.
@@ -98,6 +99,27 @@ Every graphic is also available as a plain URL you can drop into any markdown fi
 <!-- GitHub stats card -->
 ![GitHub Stats](https://your-service.run.app/stats-card?username=octocat)
 
+<!-- Languages worked in recently, weighted by commit activity -->
+![Active Languages](https://your-service.run.app/active-languages?username=octocat&days=90)
+
+<!-- Cumulative language-usage-over-time, stacked area -->
+![Language Trend](https://your-service.run.app/language-trend?limit=8)
+
+<!-- Day-by-hour activity clock -->
+![Activity Clock](https://your-service.run.app/activity-clock?username=octocat)
+
+<!-- A grid of your most notable repositories -->
+![Top Repos](https://your-service.run.app/top-repos?username=octocat&sort=stars&limit=6)
+
+<!-- A card for a single repo -->
+![Repo Card](https://your-service.run.app/repo-card?repo=octocat/Hello-World)
+
+<!-- Weekly commit activity for a single repo -->
+![Repo Activity](https://your-service.run.app/repo-activity?repo=octocat/Hello-World)
+
+<!-- Brand badges linking to your socials -->
+![Social Links](https://your-service.run.app/social-links?links=github:octocat,linkedin:octocat)
+
 <!-- WakaTime coding time (requires a connected WakaTime key) -->
 ![Coding Time](https://your-service.run.app/wakatime?range=last_30_days)
 ```
@@ -170,16 +192,22 @@ Add `.pretty-readme.json` to your profile repository (`{username}/{username}`). 
 
 You can manage this file from the app UI or directly in GitHub. If this file doesn't exist, the cron job will refuse to run — intentional, so a fresh deploy can't accidentally bulk-update everything.
 
-The same file can opt into extra profile tiles (all off by default) via a `tiles` block — for example a contribution heatmap and a GitHub stats card:
+The same file can opt into extra profile tiles (all off by default) via a `tiles` block. The available tile ids are `contributionGraph`, `statsCard`, `languageTrend`, `socialLinks`, `activeLanguages`, `topRepos`, `activityClock`, and `wakatime` — each also a standalone endpoint you can embed directly:
 
 ```json
 {
   "repos": ["my-main-project"],
-  "tiles": { "contributionGraph": true, "statsCard": true }
+  "tiles": {
+    "contributionGraph": true,
+    "statsCard": true,
+    "activeLanguages": true,
+    "topRepos": true
+  },
+  "social": { "github": "octocat", "linkedin": "octocat" }
 }
 ```
 
-Enabled tiles are rendered as SVGs, pushed to `assets/`, and injected into your profile README between their markers on the next apply.
+Enabled tiles are rendered as SVGs (reusing the same data builders as the standalone endpoints), pushed to `assets/`, and injected into your profile README between their markers on the next apply. The `socialLinks` tile reads the top-level `social` map.
 
 ### Step 2 — Add the workflow
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -148,8 +148,10 @@ language badges, opt-in account tiles, `DEVELOPER_INSIGHTS.md`) plus an
 injecting each between its README markers. Supports **Server-Sent Events** when the
 request `Accept`s `text/event-stream`. Opt-in account tiles enabled in
 `.pretty-readme.json` (`tiles.contributionGraph`, `tiles.statsCard`,
-`tiles.languageTrend`, `tiles.socialLinks`) are rendered, pushed to `assets/`, and
-injected between their markers.
+`tiles.languageTrend`, `tiles.socialLinks`, `tiles.activeLanguages`,
+`tiles.topRepos`, `tiles.activityClock`, `tiles.wakatime`) are rendered, pushed to
+`assets/`, and injected between their markers. Each tile reuses the same data
+builder as its standalone endpoint, so the apply output stays in lock-step.
 
 | Parameter | Default | Description |
 | :-------- | :------ | :---------- |
@@ -348,6 +350,42 @@ non-fork). Returns a JSON summary.
 | :-------- | :------ | :---------- |
 | `dry_run` | `false` | `true` returns suggestions without applying. |
 
+### GET /active-languages
+
+Generates an SVG bar tile of the languages a user has worked in **recently**,
+weighted by commit activity inside the window (not lifetime repo bytes). Results
+are cached for 1h per `(username, days)`. Always responds `image/svg+xml` — a
+missing user or any error renders a graceful empty tile, never a 4xx/5xx body.
+
+| Parameter    | Default | Description |
+| :----------- | :------ | :---------- |
+| `username`   |         | GitHub login whose recent activity is charted (required; absent renders an empty tile). |
+| `days`       | `90`    | Recent window in days. Values `<= 0` or non-numeric fall back to `90`; capped at `365`. |
+| `background` | `null`  | Theme: `cherry-blossom`, `geometric`, or `vapor-wave`. |
+
+**Example:**
+```
+http://localhost:8088/active-languages?username=octocat&days=180&background=geometric
+```
+
+### GET /activity-clock
+
+Renders a 7×24 (day-of-week × hour-of-day) heatmap SVG of a user's coding
+activity, derived from GitHub public-event timestamps, with the busiest day and
+busiest hour labelled. Falls back to a graceful empty-state tile when no
+contribution data is available; returns **500** with a plain-text body on an
+unexpected error.
+
+| Parameter    | Default | Description |
+| :----------- | :------ | :---------- |
+| `username`   |         | GitHub login (required; absent renders an empty tile). |
+| `background` | `null`  | Theme: `cherry-blossom`, `geometric`, or `vapor-wave`. |
+
+**Example:**
+```
+http://localhost:8088/activity-clock?username=octocat&background=vapor-wave
+```
+
 ### GET /monkeytype
 
 Generates an SVG typing-speed chart from Monkeytype personal bests (standard English
@@ -363,6 +401,114 @@ the key from the session or `WAKATIME_API_KEY`. `401` when no key is connected;
 | Parameter | Default        | Description |
 | :-------- | :------------- | :---------- |
 | `range`   | `last_7_days`  | `last_7_days`, `last_30_days`, `last_6_months`, `last_year`, or `all_time`. |
+
+### GET /language-trend
+
+Approximates how a user's language usage has grown over time: it buckets each
+repository's language bytes by the repo's creation year and renders a cumulative
+**stacked-area** chart. Reads the session GitHub token when present, else
+`GITHUB_TOKEN`. Cached for 15 minutes per `(user, repos, limit)`. `401` when no
+GitHub token is available.
+
+| Parameter  | Default | Description |
+| :--------- | :------ | :---------- |
+| `repos`    | `40`    | Cap on the number of (largest, non-fork) repos scanned for `/languages` (min 1). |
+| `limit`    | `6`     | Max languages shown as stacked series (min 1). |
+| `username` | `env`   | Cache key when unauthenticated (the session user takes precedence when signed in). |
+
+**Example:**
+```
+http://localhost:8088/language-trend?repos=60&limit=8
+```
+
+### GET /social-links
+
+Renders a row of brand badges linking to a user's social profiles. Links come
+(in order) from the `?links=` query param, or — when authenticated — the `social`
+map in the user's `.pretty-readme.json`. Unknown platforms degrade to a generic
+link badge. Known platform keys include `github`, `twitter`/`x`, `linkedin`,
+`devto`/`dev`, `mastodon`, `youtube`, `instagram`, `twitch`, `discord`,
+`stackoverflow`, `medium`, `reddit`, `gitlab`, `bluesky`, `telegram`, `facebook`,
+`dribbble`, `behance`, `email`/`mail`, `website`/`web`, and `blog`.
+
+| Parameter  | Default | Description |
+| :--------- | :------ | :---------- |
+| `links`    |         | Comma-separated `platform:handle` pairs, e.g. `github:octocat,email:me@example.com`. Overrides config when present. The handle may itself contain colons (full URLs); only the first colon splits the pair. |
+| `username` |         | When unauthenticated and `links` is omitted, the login whose `.pretty-readme.json` `social` map is read (requires a `GITHUB_TOKEN`). |
+
+**Example:**
+```
+http://localhost:8088/social-links?links=github:octocat,linkedin:octocat,email:octocat@github.com
+```
+
+### GET /repo-tech-badges
+
+Returns a **Markdown** (plain-text) row of shields.io tech badges derived from a
+repo's primary language and topics. `200` with an empty body when no tech is
+detected; `400` for a missing/malformed `repo`; `404` when the repo is not found;
+`502` on an upstream fetch error.
+
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `repo`    |         | **Required.** `owner/name`. |
+
+**Example:**
+```
+http://localhost:8088/repo-tech-badges?repo=octocat/Hello-World
+```
+
+### GET /repo-card
+
+Renders a theme-aware SVG card for a single repo with its stars, forks, open
+issues, primary language, and last-updated time, sourced from the REST repo
+object. `400` for a missing/malformed `repo`; `404` when not found; `502` on an
+upstream fetch error.
+
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `repo`    |         | **Required.** `owner/name`. |
+
+**Example:**
+```
+http://localhost:8088/repo-card?repo=octocat/Hello-World
+```
+
+### GET /repo-activity
+
+Renders the repository's weekly commit activity for the last year as a themed SVG
+bar chart. Always responds `image/svg+xml` — error and empty states render as SVG
+cards so the image never breaks in a README.
+
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `repo`    |         | **Required.** `owner/name`, or a bare `name` combined with `user=`. A missing/unresolvable value renders a `Use ?repo=owner/name` SVG card. |
+| `user`    |         | Owner login, used when `repo` is a bare name. |
+
+**Example:**
+```
+http://localhost:8088/repo-activity?repo=octocat/Hello-World
+http://localhost:8088/repo-activity?user=octocat&repo=Hello-World
+```
+
+### GET /top-repos
+
+Renders a grid of repo cards for a user's most notable repositories (reusing the
+repo-card renderer). Forks are excluded by default; an empty selection renders a
+graceful placeholder. `400` for a missing `username`; `502` on an upstream fetch
+error.
+
+| Parameter  | Default | Description |
+| :--------- | :------ | :---------- |
+| `username` |         | **Required.** GitHub login. |
+| `sort`     | `stars` | `stars` or `updated` (most recently pushed). |
+| `limit`    | `6`     | Number of cards (clamped to 1–12). |
+| `columns`  | `2`     | Grid columns. |
+| `forks`    | `false` | `true`/`1` includes forks. |
+
+**Example:**
+```
+http://localhost:8088/top-repos?username=octocat&sort=updated&limit=8&columns=3
+```
 
 ---
 


### PR DESCRIPTION
Final docs pass for #72. Documents all 44 manifest routes accurately: the 2 new Phase 5 endpoints (/active-languages, /activity-clock), the 6 newly-mounted endpoints (#103), and the 8 opt-in tiles in apply/preview (#70). Removes stale 'not mounted / apply-time only' claims. Updates README, docs/api.md, dev.to.md. Supersedes the earlier phase5-docs branch.